### PR TITLE
Migrate UI to Tailwind v4 (drop Bootstrap) + live recolor, on-map legend, sticky Run

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en" data-bs-theme="dark">
+<html lang="en" class="dark">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/package.json
+++ b/package.json
@@ -16,19 +16,18 @@
   },
   "dependencies": {
     "@vueuse/core": "^12.8.2",
-    "bootstrap": "^5.3.8",
     "d3-contour": "^4.0.2",
     "maplibre-gl": "^5.24.0",
     "pinia": "^2.3.1",
     "randanimal": "^1.0.4",
-    "vue": "^3.5.20",
-    "vue3-popper": "^1.5.0"
+    "vue": "^3.5.20"
   },
   "devDependencies": {
-    "@types/bootstrap": "^5.2.10",
+    "@tailwindcss/vite": "^4.3.1",
     "@types/d3-contour": "^3.0.6",
     "@types/geojson": "^7946.0.16",
     "@vitejs/plugin-vue": "^6.0.1",
+    "tailwindcss": "^4.3.1",
     "typescript": "~5.9.2",
     "vite": "^7.3.2",
     "vitest": "^4.1.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,9 +18,6 @@ importers:
       '@vueuse/core':
         specifier: ^12.8.2
         version: 12.8.2(typescript@5.9.2)
-      bootstrap:
-        specifier: ^5.3.8
-        version: 5.3.8(@popperjs/core@2.11.8)
       d3-contour:
         specifier: ^4.0.2
         version: 4.0.2
@@ -36,13 +33,10 @@ importers:
       vue:
         specifier: ^3.5.20
         version: 3.5.20(typescript@5.9.2)
-      vue3-popper:
-        specifier: ^1.5.0
-        version: 1.5.0(vue@3.5.20(typescript@5.9.2))
     devDependencies:
-      '@types/bootstrap':
-        specifier: ^5.2.10
-        version: 5.2.10
+      '@tailwindcss/vite':
+        specifier: ^4.3.1
+        version: 4.3.1(vite@7.3.5(jiti@2.7.0)(lightningcss@1.32.0))
       '@types/d3-contour':
         specifier: ^3.0.6
         version: 3.0.6
@@ -51,16 +45,19 @@ importers:
         version: 7946.0.16
       '@vitejs/plugin-vue':
         specifier: ^6.0.1
-        version: 6.0.1(vite@7.3.5)(vue@3.5.20(typescript@5.9.2))
+        version: 6.0.1(vite@7.3.5(jiti@2.7.0)(lightningcss@1.32.0))(vue@3.5.20(typescript@5.9.2))
+      tailwindcss:
+        specifier: ^4.3.1
+        version: 4.3.1
       typescript:
         specifier: ~5.9.2
         version: 5.9.2
       vite:
         specifier: ^7.3.2
-        version: 7.3.5
+        version: 7.3.5(jiti@2.7.0)(lightningcss@1.32.0)
       vitest:
         specifier: ^4.1.8
-        version: 4.1.8(vite@7.3.5)
+        version: 4.1.8(vite@7.3.5(jiti@2.7.0)(lightningcss@1.32.0))
       vue-tsc:
         specifier: ^3.0.6
         version: 3.0.6(typescript@5.9.2)
@@ -240,8 +237,21 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@jridgewell/gen-mapping@0.3.13':
+    resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
+
+  '@jridgewell/remapping@2.3.5':
+    resolution: {integrity: sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==}
+
+  '@jridgewell/resolve-uri@3.1.2':
+    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
+    engines: {node: '>=6.0.0'}
+
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
   '@mapbox/jsonlint-lines-primitives@2.0.2':
     resolution: {integrity: sha512-rY0o9A5ECsTQRVhv7tL/OyDpGAoUB4tTvLiW1DSzQGq4bvTPhNw1VpSNjDJc5GFZ2XuyOtSWSVN05qOtcD71qQ==}
@@ -278,9 +288,6 @@ packages:
 
   '@maplibre/vt-pbf@4.3.2':
     resolution: {integrity: sha512-j6p0AdjvAR19Z3XaCysle7A4ZSo08tYOzxD0Y9NQylwPAkwJJeYub5b2eVucdeDh7erhv69DahoLOevDRERRUw==}
-
-  '@popperjs/core@2.11.8':
-    resolution: {integrity: sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==}
 
   '@rolldown/pluginutils@1.0.0-beta.29':
     resolution: {integrity: sha512-NIJgOsMjbxAXvoGq/X0gD7VPMQ8j9g0BiDaNjVNVjvl+iKXxL3Jre0v31RmBYeLEmkbj2s02v8vFTbUXi5XS2Q==}
@@ -413,8 +420,95 @@ packages:
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
-  '@types/bootstrap@5.2.10':
-    resolution: {integrity: sha512-F2X+cd6551tep0MvVZ6nM8v7XgGN/twpdNDjqS1TUM7YFNEtQYWk+dKAnH+T1gr6QgCoGMPl487xw/9hXooa2g==}
+  '@tailwindcss/node@4.3.1':
+    resolution: {integrity: sha512-6NDaqRoAMSXD1mr/RXu0HBvNE9a2n5tHPsxu9XHLws8o4Twes5rBM2205SUUiJ9goAtadrN6xTGX0UDEwp/N4A==}
+
+  '@tailwindcss/oxide-android-arm64@4.3.1':
+    resolution: {integrity: sha512-SVlyf61g374l5cHyg8x9kf5xmLcOaxvOTsbsqDnSsDJaKOEFZ7GCvi84VAVGpxojYOs1+3K6M0UjXfqPU8vmOQ==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [android]
+
+  '@tailwindcss/oxide-darwin-arm64@4.3.1':
+    resolution: {integrity: sha512-hVnWLwv+e/l7c4WKyVtHVrIPvYdqWHjRB3MDIqARynzFtnQg85kmQEFCbV9Ja0VVx4xXTIiDWY60Y7iz/iNoDA==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@tailwindcss/oxide-darwin-x64@4.3.1':
+    resolution: {integrity: sha512-Cf7abu0WVgbhU7ANgPUnSAvm7nCvMweusHb8FnaHlLfv/Caq4GYaEZg7ZImzzmjx4lIAfuS8q+eLIS7A7IzxIg==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@tailwindcss/oxide-freebsd-x64@4.3.1':
+    resolution: {integrity: sha512-ZZqzX2Y+GXtXXfqSfpJhDm60OoZfvLHLCgm+J7NVqgHHJjG/m9ugZI77RwTsVd4fnBJuCFP6Ae6kTJb71UdS8g==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@tailwindcss/oxide-linux-arm-gnueabihf@4.3.1':
+    resolution: {integrity: sha512-/Ah/xik0LaMYfv9DZ0S/t4pBlBNYOcqtRwusjgovHkvT8ixueWCLyJjsaF5kQIckjb4IT8Q6K6p/iPmZMixYgg==}
+    engines: {node: '>= 20'}
+    cpu: [arm]
+    os: [linux]
+
+  '@tailwindcss/oxide-linux-arm64-gnu@4.3.1':
+    resolution: {integrity: sha512-gqdFoVJlw444GvpnheZLHmvTzSxI/cOUUh2KSNejQjTcYkW062SVD+En0rUgD+QV91bz1XGIGtt1HJd48xUGbQ==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@tailwindcss/oxide-linux-arm64-musl@4.3.1':
+    resolution: {integrity: sha512-Bwv9KwOvE0VKa86xPFif9b9c3Y1NxOV1P0gLti/IYaWEsQYZXDlxfGEtA8mdDZ7SG3wyNXAWYT5SIn3giL57oA==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@tailwindcss/oxide-linux-x64-gnu@4.3.1':
+    resolution: {integrity: sha512-Ymi8O8T15HYQdOUWUtTI6ldN0neHP85FC+Qz32xTcZ7iJXtem/x8ITev0o1e9e5rkqj4lONZfTRLvkmin1+tKg==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [linux]
+
+  '@tailwindcss/oxide-linux-x64-musl@4.3.1':
+    resolution: {integrity: sha512-M+P/91qJ6uILLw4k2G93GMDRAXj61SMvFQYt39AqvUqYgExXpLL5aepfns7sj4HiAQeolirQF9E0lzRvdf4zPQ==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [linux]
+
+  '@tailwindcss/oxide-wasm32-wasi@4.3.1':
+    resolution: {integrity: sha512-zsM8uOeqvVGHsAXsJxsT28ttosFahLJKCLOTUBqRAtKnVgGSRitds9T432QiT8b77Yga7JIBkulIRRlJPtYhRA==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+    bundledDependencies:
+      - '@napi-rs/wasm-runtime'
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+      - '@tybys/wasm-util'
+      - '@emnapi/wasi-threads'
+      - tslib
+
+  '@tailwindcss/oxide-win32-arm64-msvc@4.3.1':
+    resolution: {integrity: sha512-aiNvSq9BsVk8V513lDKlrCFAgf8qBMPZTpgEhInL+NwQqs97mYmupVMrPrgBBSL8Pv/0zXu9MrMF9rMun1ZeNg==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@tailwindcss/oxide-win32-x64-msvc@4.3.1':
+    resolution: {integrity: sha512-xDEyu1rg290472FEGaKHnzyDyh5QH+AlWvsU5hMoMtPpzmKlRI0jaYKCgSHDYtaQWZOYbMaduSyCwFwY4n1HmA==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [win32]
+
+  '@tailwindcss/oxide@4.3.1':
+    resolution: {integrity: sha512-yVPyo8RNkabVr3O2EhHEE0Rewu7YKzc1DhIqfL46LKveFrmu9XbDazNOJY7/GRuvw1h6u3utWnR29H/p5JPlgA==}
+    engines: {node: '>= 20'}
+
+  '@tailwindcss/vite@4.3.1':
+    resolution: {integrity: sha512-hItDHuIIlEV61R+faXu66s1K36aTurO/Qw0e45Vskz57gXl9pWOT6eg3zmcEui6CZXddbN7zd41bwmvag4JGwQ==}
+    peerDependencies:
+      vite: ^5.2.0 || ^6 || ^7 || ^8
 
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
@@ -544,11 +638,6 @@ packages:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
 
-  bootstrap@5.3.8:
-    resolution: {integrity: sha512-HP1SZDqaLDPwsNiqRqi5NcP0SSXciX2s9E+RyqJIIqGo+vJeN5AJVM98CXmW/Wux0nQ5L7jeWUdplCEf0Ee+tg==}
-    peerDependencies:
-      '@popperjs/core': ^2.11.8
-
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
     engines: {node: '>=18'}
@@ -570,11 +659,16 @@ packages:
   de-indent@1.0.2:
     resolution: {integrity: sha512-e/1zu3xH5MQryN2zdVaF0OrdNLUbvWxzMbi+iNA6Bky7l1RoP8a2fIbRocyHclXt/arDrrR6lL3TqFD9pMQTsg==}
 
-  debounce@1.2.1:
-    resolution: {integrity: sha512-XRRe6Glud4rd/ZGQfiV1ruXSfbvfJedlV9Y6zOlP+2K04vBYiJEte6stfFkCP03aMnY5tsipamumUjL14fofug==}
+  detect-libc@2.1.2:
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
+    engines: {node: '>=8'}
 
   earcut@3.0.2:
     resolution: {integrity: sha512-X7hshQbLyMJ/3RPhyObLARM2sNxxmRALLKx1+NVFFnQ9gKzmCrxm9+uLIAdBcvc8FNLpctqlQ2V6AE92Ol9UDQ==}
+
+  enhanced-resolve@5.21.6:
+    resolution: {integrity: sha512-aNnGCvbJ/RIyWo1IuhNdVjnNF+EjH9wpzpNHt+ci/m9He9LJvUN8wrCcXjp9cWsGNAuvSpVFTx/vraAFQ8qGjQ==}
+    engines: {node: '>=10.13.0'}
 
   entities@4.5.0:
     resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
@@ -615,6 +709,9 @@ packages:
   gl-matrix@3.4.4:
     resolution: {integrity: sha512-latSnyDNt/8zYUB6VIJ6PCh2jBjJX6gnDsoCZ7LyW7GkqrD51EWwa9qCoGixj8YqBtETQK/xY7OmpTF8xz1DdQ==}
 
+  graceful-fs@4.2.11:
+    resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
   he@1.2.0:
     resolution: {integrity: sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==}
     hasBin: true
@@ -623,11 +720,85 @@ packages:
     resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
     engines: {node: '>=12'}
 
+  jiti@2.7.0:
+    resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
+    hasBin: true
+
   json-stringify-pretty-compact@4.0.0:
     resolution: {integrity: sha512-3CNZ2DnrpByG9Nqj6Xo8vqbjT4F6N+tb4Gb28ESAZjYZ5yqvmc56J+/kuIwkaAMOyblTQhUW7PxMkUb8Q36N3Q==}
 
   kdbush@4.1.0:
     resolution: {integrity: sha512-e9vurzrXJQrFX6ckpHP3bvj5l+9CnYzkxDNnNQ1h2QTqdWsUAJgXiKdGNcOa1EY85dU8KbQ+z/FdQdB7P+9yfQ==}
+
+  lightningcss-android-arm64@1.32.0:
+    resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [android]
+
+  lightningcss-darwin-arm64@1.32.0:
+    resolution: {integrity: sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  lightningcss-darwin-x64@1.32.0:
+    resolution: {integrity: sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  lightningcss-freebsd-x64@1.32.0:
+    resolution: {integrity: sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    resolution: {integrity: sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm]
+    os: [linux]
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    resolution: {integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  lightningcss-linux-x64-musl@1.32.0:
+    resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    resolution: {integrity: sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [win32]
+
+  lightningcss@1.32.0:
+    resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
+    engines: {node: '>= 12.0.0'}
 
   magic-string@0.30.18:
     resolution: {integrity: sha512-yi8swmWbO17qHhwIBNeeZxTceJMeBvWJaId6dyvTSOwTipqeHhMhOrz6513r1sOKnpvQ7zkhlG8tPrpilwTxHQ==}
@@ -723,6 +894,13 @@ packages:
 
   std-env@4.1.0:
     resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
+
+  tailwindcss@4.3.1:
+    resolution: {integrity: sha512-hk+TB1m+K8CYNrP6rjQaq/Y+4Zylwpa87mLYBKCunwnnQ9p+fHb7kmSfGqyEJoxF/O6CDyABWVFEafNSYKll+Q==}
+
+  tapable@2.3.3:
+    resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
+    engines: {node: '>=6'}
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
@@ -848,12 +1026,6 @@ packages:
     peerDependencies:
       typescript: '>=5.0.0'
 
-  vue3-popper@1.5.0:
-    resolution: {integrity: sha512-xaEnx90YBnlSg5G2yWqm2DHWHg+DB99UVRp4VsyTF0QLXyHrqSuE1Xo5+sG0AQq/lBcrGMlk5NU5xE2MDLKViw==}
-    engines: {node: '>=12'}
-    peerDependencies:
-      vue: ^3.2.20
-
   vue@3.5.20:
     resolution: {integrity: sha512-2sBz0x/wis5TkF1XZ2vH25zWq3G1bFEPOfkBcx2ikowmphoQsPH6X0V3mmPCXA2K1N/XGTnifVyDQP4GfDDeQw==}
     peerDependencies:
@@ -960,7 +1132,24 @@ snapshots:
   '@esbuild/win32-x64@0.28.1':
     optional: true
 
+  '@jridgewell/gen-mapping@0.3.13':
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/remapping@2.3.5':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/resolve-uri@3.1.2': {}
+
   '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
 
   '@mapbox/jsonlint-lines-primitives@2.0.2': {}
 
@@ -1002,8 +1191,6 @@ snapshots:
       '@mapbox/point-geometry': 1.1.0
       '@types/geojson': 7946.0.16
       pbf: 5.1.0
-
-  '@popperjs/core@2.11.8': {}
 
   '@rolldown/pluginutils@1.0.0-beta.29': {}
 
@@ -1084,9 +1271,73 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
-  '@types/bootstrap@5.2.10':
+  '@tailwindcss/node@4.3.1':
     dependencies:
-      '@popperjs/core': 2.11.8
+      '@jridgewell/remapping': 2.3.5
+      enhanced-resolve: 5.21.6
+      jiti: 2.7.0
+      lightningcss: 1.32.0
+      magic-string: 0.30.21
+      source-map-js: 1.2.1
+      tailwindcss: 4.3.1
+
+  '@tailwindcss/oxide-android-arm64@4.3.1':
+    optional: true
+
+  '@tailwindcss/oxide-darwin-arm64@4.3.1':
+    optional: true
+
+  '@tailwindcss/oxide-darwin-x64@4.3.1':
+    optional: true
+
+  '@tailwindcss/oxide-freebsd-x64@4.3.1':
+    optional: true
+
+  '@tailwindcss/oxide-linux-arm-gnueabihf@4.3.1':
+    optional: true
+
+  '@tailwindcss/oxide-linux-arm64-gnu@4.3.1':
+    optional: true
+
+  '@tailwindcss/oxide-linux-arm64-musl@4.3.1':
+    optional: true
+
+  '@tailwindcss/oxide-linux-x64-gnu@4.3.1':
+    optional: true
+
+  '@tailwindcss/oxide-linux-x64-musl@4.3.1':
+    optional: true
+
+  '@tailwindcss/oxide-wasm32-wasi@4.3.1':
+    optional: true
+
+  '@tailwindcss/oxide-win32-arm64-msvc@4.3.1':
+    optional: true
+
+  '@tailwindcss/oxide-win32-x64-msvc@4.3.1':
+    optional: true
+
+  '@tailwindcss/oxide@4.3.1':
+    optionalDependencies:
+      '@tailwindcss/oxide-android-arm64': 4.3.1
+      '@tailwindcss/oxide-darwin-arm64': 4.3.1
+      '@tailwindcss/oxide-darwin-x64': 4.3.1
+      '@tailwindcss/oxide-freebsd-x64': 4.3.1
+      '@tailwindcss/oxide-linux-arm-gnueabihf': 4.3.1
+      '@tailwindcss/oxide-linux-arm64-gnu': 4.3.1
+      '@tailwindcss/oxide-linux-arm64-musl': 4.3.1
+      '@tailwindcss/oxide-linux-x64-gnu': 4.3.1
+      '@tailwindcss/oxide-linux-x64-musl': 4.3.1
+      '@tailwindcss/oxide-wasm32-wasi': 4.3.1
+      '@tailwindcss/oxide-win32-arm64-msvc': 4.3.1
+      '@tailwindcss/oxide-win32-x64-msvc': 4.3.1
+
+  '@tailwindcss/vite@4.3.1(vite@7.3.5(jiti@2.7.0)(lightningcss@1.32.0))':
+    dependencies:
+      '@tailwindcss/node': 4.3.1
+      '@tailwindcss/oxide': 4.3.1
+      tailwindcss: 4.3.1
+      vite: 7.3.5(jiti@2.7.0)(lightningcss@1.32.0)
 
   '@types/chai@5.2.3':
     dependencies:
@@ -1110,10 +1361,10 @@ snapshots:
 
   '@types/web-bluetooth@0.0.21': {}
 
-  '@vitejs/plugin-vue@6.0.1(vite@7.3.5)(vue@3.5.20(typescript@5.9.2))':
+  '@vitejs/plugin-vue@6.0.1(vite@7.3.5(jiti@2.7.0)(lightningcss@1.32.0))(vue@3.5.20(typescript@5.9.2))':
     dependencies:
       '@rolldown/pluginutils': 1.0.0-beta.29
-      vite: 7.3.5
+      vite: 7.3.5(jiti@2.7.0)(lightningcss@1.32.0)
       vue: 3.5.20(typescript@5.9.2)
 
   '@vitest/expect@4.1.8':
@@ -1125,13 +1376,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.8(vite@7.3.5)':
+  '@vitest/mocker@4.1.8(vite@7.3.5(jiti@2.7.0)(lightningcss@1.32.0))':
     dependencies:
       '@vitest/spy': 4.1.8
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.5
+      vite: 7.3.5(jiti@2.7.0)(lightningcss@1.32.0)
 
   '@vitest/pretty-format@4.1.8':
     dependencies:
@@ -1264,10 +1515,6 @@ snapshots:
 
   assertion-error@2.0.1: {}
 
-  bootstrap@5.3.8(@popperjs/core@2.11.8):
-    dependencies:
-      '@popperjs/core': 2.11.8
-
   chai@6.2.2: {}
 
   convert-source-map@2.0.0: {}
@@ -1284,9 +1531,14 @@ snapshots:
 
   de-indent@1.0.2: {}
 
-  debounce@1.2.1: {}
+  detect-libc@2.1.2: {}
 
   earcut@3.0.2: {}
+
+  enhanced-resolve@5.21.6:
+    dependencies:
+      graceful-fs: 4.2.11
+      tapable: 2.3.3
 
   entities@4.5.0: {}
 
@@ -1338,13 +1590,66 @@ snapshots:
 
   gl-matrix@3.4.4: {}
 
+  graceful-fs@4.2.11: {}
+
   he@1.2.0: {}
 
   internmap@2.0.3: {}
 
+  jiti@2.7.0: {}
+
   json-stringify-pretty-compact@4.0.0: {}
 
   kdbush@4.1.0: {}
+
+  lightningcss-android-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-x64@1.32.0:
+    optional: true
+
+  lightningcss-freebsd-x64@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-musl@1.32.0:
+    optional: true
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    optional: true
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    optional: true
+
+  lightningcss@1.32.0:
+    dependencies:
+      detect-libc: 2.1.2
+    optionalDependencies:
+      lightningcss-android-arm64: 1.32.0
+      lightningcss-darwin-arm64: 1.32.0
+      lightningcss-darwin-x64: 1.32.0
+      lightningcss-freebsd-x64: 1.32.0
+      lightningcss-linux-arm-gnueabihf: 1.32.0
+      lightningcss-linux-arm64-gnu: 1.32.0
+      lightningcss-linux-arm64-musl: 1.32.0
+      lightningcss-linux-x64-gnu: 1.32.0
+      lightningcss-linux-x64-musl: 1.32.0
+      lightningcss-win32-arm64-msvc: 1.32.0
+      lightningcss-win32-x64-msvc: 1.32.0
 
   magic-string@0.30.18:
     dependencies:
@@ -1469,6 +1774,10 @@ snapshots:
 
   std-env@4.1.0: {}
 
+  tailwindcss@4.3.1: {}
+
+  tapable@2.3.3: {}
+
   tinybench@2.9.0: {}
 
   tinyexec@1.2.4: {}
@@ -1484,7 +1793,7 @@ snapshots:
 
   typescript@5.9.2: {}
 
-  vite@7.3.5:
+  vite@7.3.5(jiti@2.7.0)(lightningcss@1.32.0):
     dependencies:
       esbuild: 0.28.1
       fdir: 6.5.0(picomatch@4.0.4)
@@ -1494,11 +1803,13 @@ snapshots:
       tinyglobby: 0.2.17
     optionalDependencies:
       fsevents: 2.3.3
+      jiti: 2.7.0
+      lightningcss: 1.32.0
 
-  vitest@4.1.8(vite@7.3.5):
+  vitest@4.1.8(vite@7.3.5(jiti@2.7.0)(lightningcss@1.32.0)):
     dependencies:
       '@vitest/expect': 4.1.8
-      '@vitest/mocker': 4.1.8(vite@7.3.5)
+      '@vitest/mocker': 4.1.8(vite@7.3.5(jiti@2.7.0)(lightningcss@1.32.0))
       '@vitest/pretty-format': 4.1.8
       '@vitest/runner': 4.1.8
       '@vitest/snapshot': 4.1.8
@@ -1515,7 +1826,7 @@ snapshots:
       tinyexec: 1.2.4
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
-      vite: 7.3.5
+      vite: 7.3.5(jiti@2.7.0)(lightningcss@1.32.0)
       why-is-node-running: 2.3.0
     transitivePeerDependencies:
       - msw
@@ -1531,12 +1842,6 @@ snapshots:
       '@volar/typescript': 2.4.23
       '@vue/language-core': 3.0.6(typescript@5.9.2)
       typescript: 5.9.2
-
-  vue3-popper@1.5.0(vue@3.5.20(typescript@5.9.2)):
-    dependencies:
-      '@popperjs/core': 2.11.8
-      debounce: 1.2.1
-      vue: 3.5.20(typescript@5.9.2)
 
   vue@3.5.20(typescript@5.9.2):
     dependencies:

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,142 +1,128 @@
 <template>
   <div>
-    <nav class="navbar mt-navbar fixed-top">
-      <div class="container-fluid">
-        <a class="navbar-brand" href="#">
-          <img src="/logo.svg" alt="Meshtastic logo" width="34" height="18" class="d-inline">
-          <span>Meshtastic <span class="fw-normal">Site Planner</span></span>
-        </a>
-        <button class="navbar-toggler" type="button" data-bs-toggle="offcanvas" data-bs-target="#paramsPanel" aria-controls="paramsPanel" aria-label="Toggle site parameters">
-          <span class="navbar-toggler-icon"></span>
-        </button>
-      </div>
+    <!-- App header -->
+    <nav class="fixed inset-x-0 top-0 z-[1100] flex h-[57px] items-center justify-between border-b border-line bg-sunken px-4">
+      <a href="#" class="flex items-center gap-2.5 font-semibold tracking-[0.01em] text-ink no-underline">
+        <img src="/logo.svg" alt="Meshtastic logo" width="34" height="18" class="inline-block" />
+        <span>Meshtastic <span class="font-normal text-ink-muted">Site Planner</span></span>
+      </a>
+      <button
+        type="button"
+        class="mt-btn mt-btn-ghost mt-btn-sm gap-2"
+        :aria-pressed="panelOpen"
+        aria-label="Toggle site parameters"
+        @click="panelOpen = !panelOpen"
+      >
+        <svg viewBox="0 0 24 24" class="size-4" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <line x1="4" y1="6" x2="20" y2="6" /><circle cx="9" cy="6" r="2" fill="currentColor" stroke="none" />
+          <line x1="4" y1="12" x2="20" y2="12" /><circle cx="15" cy="12" r="2" fill="currentColor" stroke="none" />
+          <line x1="4" y1="18" x2="20" y2="18" /><circle cx="7" cy="18" r="2" fill="currentColor" stroke="none" />
+        </svg>
+        <span class="hidden sm:inline">Parameters</span>
+      </button>
     </nav>
 
-    <div class="offcanvas offcanvas-end mt-sidebar show" tabindex="-1" id="paramsPanel" aria-labelledby="paramsPanelLabel" data-bs-backdrop="false" data-bs-scroll="true">
-      <div class="offcanvas-header">
-        <h5 class="offcanvas-title" id="paramsPanelLabel">Site Parameters</h5>
-        <button type="button" class="btn-close btn-close-white" data-bs-dismiss="offcanvas" aria-label="Close"></button>
+    <!-- Map fills the viewport; the drawer overlays its right edge. -->
+    <div id="map" ref="map"></div>
+
+    <MapLegend />
+
+    <!-- Dim + dismiss on small screens only (desktop keeps the map usable). -->
+    <div v-if="panelOpen" class="fixed inset-0 top-[57px] z-[999] bg-black/40 lg:hidden" @click="panelOpen = false"></div>
+
+    <AppDrawer v-model="panelOpen" title="Site Parameters">
+      <Section title="Site / Transmitter" :default-open="true"><Transmitter /></Section>
+      <Section title="Receiver"><Receiver /></Section>
+      <Section title="Environment"><Environment /></Section>
+      <Section title="Simulation Options"><Simulation /></Section>
+      <Section title="Display" :default-open="true"><Display /></Section>
+      <Section title="Point-to-point link"><PointToPoint /></Section>
+
+      <div v-if="store.localSites.length" class="pt-1">
+        <div class="mb-2 text-xs font-bold tracking-[0.08em] text-ink-muted uppercase">Simulated sites</div>
+        <ul class="space-y-1.5">
+          <li
+            v-for="(site, index) in store.localSites"
+            :key="site.id"
+            class="flex min-h-[44px] items-center gap-1 rounded-lg border border-line bg-surface px-2"
+            :class="{ 'opacity-60': !site.visible }"
+          >
+            <button
+              type="button"
+              class="grid size-8 shrink-0 place-items-center rounded text-ink-muted hover:text-ink"
+              :title="site.visible ? 'Hide coverage' : 'Show coverage'"
+              :aria-pressed="site.visible"
+              @click="store.toggleSiteVisibility(index)"
+            >
+              <svg v-if="site.visible" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M2 12s3.5-7 10-7 10 7 10 7-3.5 7-10 7-10-7-10-7Z"/><circle cx="12" cy="12" r="3"/></svg>
+              <svg v-else width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9.9 4.24A9.1 9.1 0 0 1 12 4c6.5 0 10 7 10 7a13.2 13.2 0 0 1-1.67 2.68"/><path d="M6.6 6.6A13.1 13.1 0 0 0 2 12s3.5 7 10 7a9 9 0 0 0 5.4-1.6"/><path d="m2 2 20 20"/></svg>
+            </button>
+            <button
+              type="button"
+              class="flex min-w-0 flex-1 items-center gap-2 truncate bg-transparent text-left text-sm text-ink hover:text-primary"
+              :title="`Go to ${site.params.transmitter.name}`"
+              @click="store.focusSite(index)"
+            >
+              <span class="size-2.5 shrink-0 rounded-full" :style="{ background: siteColor(site) }" aria-hidden="true"></span>
+              <span class="truncate">{{ site.params.transmitter.name }}</span>
+            </button>
+            <button
+              type="button"
+              class="grid size-8 shrink-0 place-items-center rounded text-ink-muted hover:text-danger"
+              :aria-label="`Remove ${site.params.transmitter.name}`"
+              @click="store.removeSite(index)"
+            >
+              <svg viewBox="0 0 24 24" class="size-4" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="m6 6 12 12M18 6 6 18"/></svg>
+            </button>
+          </li>
+        </ul>
       </div>
-      <div class="offcanvas-body d-flex flex-column">
-        <div class="accordion mt-accordion accordion-flush flex-grow-0" id="paramsAccordion">
-          <div class="accordion-item">
-            <h2 class="accordion-header">
-              <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#sectionTransmitter" aria-expanded="true" aria-controls="sectionTransmitter">
-                Site / Transmitter
-              </button>
-            </h2>
-            <div id="sectionTransmitter" class="accordion-collapse collapse show">
-              <div class="accordion-body">
-                <Transmitter />
-              </div>
-            </div>
-          </div>
-          <div class="accordion-item">
-            <h2 class="accordion-header">
-              <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#sectionReceiver" aria-expanded="false" aria-controls="sectionReceiver">
-                Receiver
-              </button>
-            </h2>
-            <div id="sectionReceiver" class="accordion-collapse collapse">
-              <div class="accordion-body">
-                <Receiver />
-              </div>
-            </div>
-          </div>
-          <div class="accordion-item">
-            <h2 class="accordion-header">
-              <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#sectionEnvironment" aria-expanded="false" aria-controls="sectionEnvironment">
-                Environment
-              </button>
-            </h2>
-            <div id="sectionEnvironment" class="accordion-collapse collapse">
-              <div class="accordion-body">
-                <Environment />
-              </div>
-            </div>
-          </div>
-          <div class="accordion-item">
-            <h2 class="accordion-header">
-              <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#sectionSimulation" aria-expanded="false" aria-controls="sectionSimulation">
-                Simulation Options
-              </button>
-            </h2>
-            <div id="sectionSimulation" class="accordion-collapse collapse">
-              <div class="accordion-body">
-                <Simulation />
-              </div>
-            </div>
-          </div>
-          <div class="accordion-item">
-            <h2 class="accordion-header">
-              <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#sectionDisplay" aria-expanded="true" aria-controls="sectionDisplay">
-                Display
-              </button>
-            </h2>
-            <div id="sectionDisplay" class="accordion-collapse collapse show">
-              <div class="accordion-body">
-                <Display />
-              </div>
-            </div>
-          </div>
-          <div class="accordion-item">
-            <h2 class="accordion-header">
-              <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#sectionP2P" aria-expanded="false" aria-controls="sectionP2P">
-                Point-to-point link
-              </button>
-            </h2>
-            <div id="sectionP2P" class="accordion-collapse collapse">
-              <div class="accordion-body">
-                <PointToPoint />
-              </div>
-            </div>
-          </div>
-        </div>
 
-        <div class="mt-3 d-flex gap-2">
-          <button :disabled="store.simulationState === 'running'" @click="store.runSimulation" type="button" class="btn btn-primary mt-run-btn flex-grow-1" id="runSimulation">
-            <span :class="{ 'd-none': store.simulationState !== 'running' }" class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span>
-            <span class="button-text">{{ buttonText() }}</span>
-          </button>
-          <button v-if="store.simulationState === 'running'" @click="store.cancelSimulation" type="button" class="btn btn-outline-light mt-run-btn">
-            Cancel
-          </button>
-        </div>
-
-        <div v-if="store.progress" class="mt-2" aria-live="polite">
-          <div class="progress mt-progress">
-            <div class="progress-bar" role="progressbar"
-              :style="{ width: (store.progress.fraction * 100).toFixed(1) + '%' }"
-              :aria-valuenow="Math.round(store.progress.fraction * 100)" aria-valuemin="0" aria-valuemax="100"></div>
-          </div>
-          <small class="mt-progress-label">{{ progressLabel() }}</small>
-        </div>
-
-        <div v-if="store.simulationState === 'failed' && store.errorMessage" class="mt-alert-error mt-2 p-2 small" role="alert">
+      <template #footer>
+        <div
+          v-if="store.simulationState === 'failed' && store.errorMessage"
+          class="mb-2 rounded-lg border border-danger bg-danger-bg p-2 text-sm text-on-danger-bg"
+          role="alert"
+        >
           {{ store.errorMessage }}
         </div>
 
-        <div v-if="store.localSites.length" class="mt-4">
-          <div class="mt-sites-heading mb-2">Simulated sites</div>
-          <ul class="list-group mt-site-list">
-            <li class="list-group-item" :class="{ 'mt-site-hidden': !site.visible }" v-for="(site, index) in store.$state.localSites" :key="site.id">
-              <button type="button" class="mt-site-eye" @click="store.toggleSiteVisibility(index)"
-                :title="site.visible ? 'Hide coverage' : 'Show coverage'" :aria-pressed="site.visible">
-                <svg v-if="site.visible" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M2 12s3.5-7 10-7 10 7 10 7-3.5 7-10 7-10-7-10-7Z"/><circle cx="12" cy="12" r="3"/></svg>
-                <svg v-else width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9.9 4.24A9.1 9.1 0 0 1 12 4c6.5 0 10 7 10 7a13.2 13.2 0 0 1-1.67 2.68"/><path d="M6.6 6.6A13.1 13.1 0 0 0 2 12s3.5 7 10 7a9 9 0 0 0 5.4-1.6"/><path d="m2 2 20 20"/></svg>
-              </button>
-              <button type="button" class="mt-site-link text-truncate" @click="store.focusSite(index)" :title="`Go to ${site.params.transmitter.name}`">
-                <span class="mt-site-dot" :style="{ background: siteColor(site) }" aria-hidden="true"></span>{{ site.params.transmitter.name }}
-              </button>
-              <button type="button" @click="store.removeSite(index)" class="btn-close" :aria-label="`Remove ${site.params.transmitter.name}`"></button>
-            </li>
-          </ul>
+        <div v-if="store.progress" class="mb-2" aria-live="polite">
+          <div class="h-2 overflow-hidden rounded-full bg-surface-3">
+            <div
+              class="h-full rounded-full bg-primary transition-[width] duration-200"
+              role="progressbar"
+              :style="{ width: (store.progress.fraction * 100).toFixed(1) + '%' }"
+              :aria-valuenow="Math.round(store.progress.fraction * 100)"
+              aria-valuemin="0"
+              aria-valuemax="100"
+            ></div>
+          </div>
+          <small class="text-[0.8125rem] text-ink-muted">{{ progressLabel() }}</small>
         </div>
-      </div>
-    </div>
 
-    <div id="map" ref="map">
-    </div>
+        <div class="flex gap-2">
+          <button
+            id="runSimulation"
+            type="button"
+            class="mt-btn mt-btn-primary flex-1"
+            :disabled="store.simulationState === 'running'"
+            @click="store.runSimulation"
+          >
+            <span v-if="store.simulationState === 'running'" class="mt-spinner" aria-hidden="true"></span>
+            <span>{{ buttonText() }}</span>
+          </button>
+          <button
+            v-if="store.simulationState === 'running'"
+            type="button"
+            class="mt-btn mt-btn-ghost"
+            @click="store.cancelSimulation"
+          >
+            Cancel
+          </button>
+        </div>
+      </template>
+    </AppDrawer>
 
     <div v-if="store.placingMode" class="mt-place-hint" role="status">
       <span><span class="mt-place-dot"></span>Click the map to place the transmitter</span>
@@ -151,39 +137,48 @@
 </template>
 
 <script setup lang="ts">
-import "bootstrap/dist/js/bootstrap.bundle.min.js"
-import Transmitter from "./components/Transmitter.vue"
-import Receiver from "./components/Receiver.vue"
-import Environment from "./components/Environment.vue"
-import Simulation from "./components/Simulation.vue"
-import Display from "./components/Display.vue"
-import PointToPoint from "./components/PointToPoint.vue"
+import { ref, onMounted } from 'vue';
+import Transmitter from './components/Transmitter.vue';
+import Receiver from './components/Receiver.vue';
+import Environment from './components/Environment.vue';
+import Simulation from './components/Simulation.vue';
+import Display from './components/Display.vue';
+import PointToPoint from './components/PointToPoint.vue';
+import AppDrawer from './components/ui/AppDrawer.vue';
+import Section from './components/ui/Section.vue';
+import MapLegend from './components/ui/MapLegend.vue';
 
-import { useStore } from './store.ts'
-import type { Site } from './types.ts'
-import { colormapLut } from './render/colormaps.ts'
-const store = useStore()
+import { useStore } from './store.ts';
+import type { Site } from './types.ts';
+import { colormapLut } from './render/colormaps.ts';
+
+const store = useStore();
+
+// Map-first on small screens; the panel opens by default on desktop.
+const panelOpen = ref(true);
+onMounted(() => {
+  if (window.matchMedia('(max-width: 1023px)').matches) panelOpen.value = false;
+});
+
 // Each site keeps its own color scale (#17); show a swatch matching its
 // overlay so sites are distinguishable in the list.
 const siteColor = (site: Site) => {
-  const lut = colormapLut(site.params.display.color_scale)
-  const i = 192 * 3 // a vivid representative sample of the colormap
-  return `rgb(${lut[i]}, ${lut[i + 1]}, ${lut[i + 2]})`
-}
+  const lut = colormapLut(site.params.display.color_scale);
+  const i = 192 * 3; // a vivid representative sample of the colormap
+  return `rgb(${lut[i]}, ${lut[i + 1]}, ${lut[i + 2]})`;
+};
+
 const buttonText = () => {
-  if ('running' === store.simulationState) {
-    return 'Running'
-  } else if ('failed' === store.simulationState) {
-    return 'Failed'
-  } else {
-    return 'Run Simulation'
-  }
-}
+  if (store.simulationState === 'running') return 'Running';
+  if (store.simulationState === 'failed') return 'Failed';
+  return 'Run Simulation';
+};
+
 const progressLabel = () => {
-  const p = store.progress
-  if (!p) return ''
-  if (p.phase === 'terrain') return `Downloading terrain (${p.completed}/${p.total} tiles)`
-  if (p.phase === 'compute') return `Computing coverage (${Math.round(p.fraction * 100)}%)`
-  return 'Rendering...'
-}
+  const p = store.progress;
+  if (!p) return '';
+  if (p.phase === 'terrain') return `Downloading terrain (${p.completed}/${p.total} tiles)`;
+  if (p.phase === 'compute') return `Computing coverage (${Math.round(p.fraction * 100)}%)`;
+  return 'Rendering…';
+};
 </script>

--- a/src/components/Display.vue
+++ b/src/components/Display.vue
@@ -1,62 +1,75 @@
 <template>
-    <form novalidate>
-        <label class="form-label">Overlay style</label>
-        <div class="btn-group w-100 mb-3" role="group" aria-label="Overlay style">
-            <button type="button" class="btn btn-sm"
-                :class="store.overlayStyle === 'heatmap' ? 'btn-primary' : 'btn-secondary'"
-                @click="store.setOverlayStyle('heatmap')">Heatmap</button>
-            <button type="button" class="btn btn-sm"
-                :class="store.overlayStyle === 'contours' ? 'btn-primary' : 'btn-secondary'"
-                @click="store.setOverlayStyle('contours')">Contours</button>
-        </div>
-        <div class="row g-2">
-            <div class="col-6">
-                <label for="min_dbm" class="form-label">Minimum dBm</label>
-                <input v-model="display.min_dbm" type="number" class="form-control form-control-sm" id="min_dbm" required step="0.1" />
-                <div class="invalid-feedback">Minimum dBm must be provided (default: -130.0).</div>
-            </div>
-            <div class="col-6">
-                <label for="max_dbm" class="form-label">Maximum dBm</label>
-                <input v-model="display.max_dbm" type="number" class="form-control form-control-sm" id="max_dbm" required step="0.1" />
-                <div class="invalid-feedback">Maximum dBm must be provided (default: -30.0).</div>
-            </div>
-        </div>
-        <div class="row g-2 mt-2">
-            <div class="col-6">
-                <label for="color_scale" class="form-label">Color Scale</label>
-                <select v-model="display.color_scale" id="color_scale" class="form-select form-select-sm" required>
-                    <option value="plasma" selected>Plasma</option>
-                    <option value="CMRmap">CMR map</option>
-                    <option value="cool">Cool</option>
-                    <option value="viridis">Viridis</option>
-                    <option value="turbo">Turbo</option>
-                    <option value="jet">Jet</option>
-                </select>
-                <div class="invalid-feedback">Please select a color scale.</div>
-            </div>
-            <div class="col-6">
-                <label for="overlay_transparency" class="form-label">Transparency (%)</label>
-                <input v-model="display.overlay_transparency" type="number" class="form-control form-control-sm" id="overlay_transparency" required min="0" max="100" step="1" />
-                <div class="invalid-feedback">Transparency must be between 0 and 100 (default: 50).</div>
-            </div>
-        </div>
-    <p class="mt-section-hint mt-3 mb-1">Display changes apply to new simulations.</p>
+  <div>
+    <label class="mt-label">Overlay style</label>
+    <div class="mb-3 flex w-full overflow-hidden rounded-lg border border-line" role="group" aria-label="Overlay style">
+      <button
+        type="button"
+        class="flex-1 py-2 text-sm font-semibold transition"
+        :class="store.overlayStyle === 'heatmap' ? 'bg-primary text-on-primary' : 'bg-surface-2 text-ink hover:bg-surface-3'"
+        @click="store.setOverlayStyle('heatmap')"
+      >
+        Heatmap
+      </button>
+      <button
+        type="button"
+        class="flex-1 border-l border-line py-2 text-sm font-semibold transition"
+        :class="store.overlayStyle === 'contours' ? 'bg-primary text-on-primary' : 'bg-surface-2 text-ink hover:bg-surface-3'"
+        @click="store.setOverlayStyle('contours')"
+      >
+        Contours
+      </button>
+    </div>
+
+    <div class="grid grid-cols-2 gap-2">
+      <div>
+        <label for="min_dbm" class="mt-label">Minimum dBm</label>
+        <input v-model="display.min_dbm" type="number" class="mt-input" id="min_dbm" step="0.1" />
+      </div>
+      <div>
+        <label for="max_dbm" class="mt-label">Maximum dBm</label>
+        <input v-model="display.max_dbm" type="number" class="mt-input" id="max_dbm" step="0.1" />
+      </div>
+      <div>
+        <label for="color_scale" class="mt-label">Color Scale</label>
+        <select v-model="display.color_scale" id="color_scale" class="mt-select">
+          <option value="plasma">Plasma</option>
+          <option value="viridis">Viridis (colorblind-safe)</option>
+          <option value="CMRmap">CMR map</option>
+          <option value="cool">Cool</option>
+          <option value="turbo">Turbo</option>
+          <option value="jet">Jet</option>
+        </select>
+      </div>
+      <div>
+        <label for="overlay_transparency" class="mt-label">Transparency (%)</label>
+        <input v-model="display.overlay_transparency" type="number" class="mt-input" id="overlay_transparency" min="0" max="100" step="1" />
+      </div>
+    </div>
+
+    <p class="mt-hint mt-3 mb-1">Changes apply instantly to existing coverage.</p>
     <div class="mt-1">
-      <img
-        :src="`/colormaps/${display.color_scale}.png`"
-        alt="Color scale preview"
-        class="mt-colorbar"
-      />
-      <div class="d-flex justify-content-between mt-1">
+      <img :src="colorbarSrc" alt="Color scale preview" class="mt-colorbar" />
+      <div class="mt-1 flex justify-between">
         <span class="mt-legend-label">{{ display.min_dbm }} dBm</span>
         <span class="mt-legend-label">{{ display.max_dbm }} dBm</span>
       </div>
     </div>
-    </form>
+  </div>
 </template>
 
 <script setup lang="ts">
-import { useStore } from "../store.ts";
+import { computed } from 'vue';
+import { watchDebounced } from '@vueuse/core';
+import { useStore } from '../store.ts';
 const store = useStore();
 const display = store.splatParams.display;
+const colorbarSrc = computed(() => `${import.meta.env.BASE_URL}colormaps/${display.color_scale}.png`);
+
+// #1 live recolor: re-render existing coverage as the controls change (no
+// recompute). Debounced so dragging through values / typing stays smooth.
+watchDebounced(
+  () => [display.color_scale, display.min_dbm, display.max_dbm, display.overlay_transparency],
+  () => store.applyDisplayLive(),
+  { debounce: 200 }
+);
 </script>

--- a/src/components/Environment.vue
+++ b/src/components/Environment.vue
@@ -1,53 +1,47 @@
 <template>
-    <form novalidate>
-        <p class="mt-section-hint mb-2">Terrain and atmosphere assumptions; the defaults suit most deployments.</p>
-        <div class="row g-2">
-            <div class="col-6">
-                <label for="radio_climate" class="form-label">Radio Climate</label>
-                <select v-model="environment.radio_climate" id="radio_climate" class="form-select form-select-sm" required>
-                    <option value="equatorial">Equatorial</option>
-                    <option value="continental_subtropical">Continental Subtropical</option>
-                    <option value="maritime_subtropical">Maritime Subtropical</option>
-                    <option value="desert">Desert</option>
-                    <option value="continental_temperate">Continental Temperate</option>
-                    <option value="maritime_temperate_land">Maritime Temperate (Land)</option>
-                    <option value="maritime_temperate_sea">Maritime Temperate (Sea)</option>
-                </select>
-                <div class="invalid-feedback">Please select a radio climate.</div>
-            </div>
-            <div class="col-6">
-                <label for="polarization" class="form-label">Polarization</label>
-                <select v-model="environment.polarization" id="polarization" class="form-select form-select-sm" required>
-                    <option value="horizontal">Horizontal</option>
-                    <option value="vertical">Vertical</option>
-                </select>
-                <div class="invalid-feedback">Please select a polarization type.</div>
-            </div>
-            <div class="col-6">
-                <label for="clutter_height" class="form-label">Clutter Height (m)</label>
-                <input v-model="environment.clutter_height" type="number" class="form-control form-control-sm" id="clutter_height" required min="0" step="0.1" />
-                <div class="invalid-feedback">Height must be >= 0 (default: 1.0).</div>
-            </div>
-            <div class="col-6">
-                <label for="ground_dielectric" class="form-label">Ground Dielectric Constant</label>
-                <input v-model="environment.ground_dielectric" type="number" class="form-control form-control-sm" id="ground_dielectric" required min="1" step="0.1" />
-                <div class="invalid-feedback">Dielectric constant must be >= 1 (default: 15.0).</div>
-            </div>
-            <div class="col-6">
-                <label for="ground_conductivity" class="form-label">Ground Conductivity (S/m)</label>
-                <input v-model="environment.ground_conductivity" type="number" class="form-control form-control-sm" id="ground_conductivity" required min="0" step="0.001" />
-                <div class="invalid-feedback">Conductivity must be >= 0 (default: 0.005).</div>
-            </div>
-            <div class="col-6">
-                <label for="atmosphere_bending" class="form-label">Atmospheric Bending (N-units)</label>
-                <input v-model="environment.atmosphere_bending" type="number" class="form-control form-control-sm" id="atmosphere_bending" required min="0" step="0.1" />
-                <div class="invalid-feedback">Bending constant must be >= 0 (default: 301.0).</div>
-            </div>
-        </div>
-    </form>
+  <div>
+    <p class="mt-hint mb-3">Terrain and atmosphere assumptions; the defaults suit most deployments.</p>
+    <div class="grid grid-cols-2 gap-2">
+      <div>
+        <label for="radio_climate" class="mt-label">Radio Climate</label>
+        <select v-model="environment.radio_climate" id="radio_climate" class="mt-select">
+          <option value="equatorial">Equatorial</option>
+          <option value="continental_subtropical">Continental Subtropical</option>
+          <option value="maritime_subtropical">Maritime Subtropical</option>
+          <option value="desert">Desert</option>
+          <option value="continental_temperate">Continental Temperate</option>
+          <option value="maritime_temperate_land">Maritime Temperate (Land)</option>
+          <option value="maritime_temperate_sea">Maritime Temperate (Sea)</option>
+        </select>
+      </div>
+      <div>
+        <label for="polarization" class="mt-label">Polarization</label>
+        <select v-model="environment.polarization" id="polarization" class="mt-select">
+          <option value="horizontal">Horizontal</option>
+          <option value="vertical">Vertical</option>
+        </select>
+      </div>
+      <div>
+        <label for="clutter_height" class="mt-label">Clutter Height (m)</label>
+        <input v-model="environment.clutter_height" type="number" class="mt-input" id="clutter_height" min="0" step="0.1" />
+      </div>
+      <div>
+        <label for="ground_dielectric" class="mt-label">Ground Dielectric Constant</label>
+        <input v-model="environment.ground_dielectric" type="number" class="mt-input" id="ground_dielectric" min="1" step="0.1" />
+      </div>
+      <div>
+        <label for="ground_conductivity" class="mt-label">Ground Conductivity (S/m)</label>
+        <input v-model="environment.ground_conductivity" type="number" class="mt-input" id="ground_conductivity" min="0" step="0.001" />
+      </div>
+      <div>
+        <label for="atmosphere_bending" class="mt-label">Atmospheric Bending (N-units)</label>
+        <input v-model="environment.atmosphere_bending" type="number" class="mt-input" id="atmosphere_bending" min="0" step="0.1" />
+      </div>
+    </div>
+  </div>
 </template>
 
 <script setup lang="ts">
-import { useStore } from '../store.ts'
+import { useStore } from '../store.ts';
 const environment = useStore().splatParams.environment;
 </script>

--- a/src/components/PointToPoint.vue
+++ b/src/components/PointToPoint.vue
@@ -1,44 +1,45 @@
 <template>
   <div>
-    <p class="mt-section-hint mb-2">
+    <p class="mt-hint mb-3">
       Analyze the link from this transmitter to one target: terrain profile,
       line of sight, Fresnel clearance, and link margin.
     </p>
 
-    <div class="d-flex gap-2">
-      <button type="button" class="btn btn-sm flex-fill"
-        :class="store.linkState === 'placing' ? 'btn-secondary active' : 'btn-primary'"
-        @click="store.beginPlaceTarget()">
-        {{ store.linkState === 'placing' ? 'Click the map…' : (store.linkTarget ? 'Move target' : 'Pick target on map') }}
+    <div class="flex gap-2">
+      <button
+        type="button"
+        class="mt-btn mt-btn-sm flex-1"
+        :class="store.linkState === 'placing' ? 'mt-btn-secondary' : 'mt-btn-primary'"
+        @click="store.beginPlaceTarget()"
+      >
+        {{ store.linkState === 'placing' ? 'Click the map…' : store.linkTarget ? 'Move target' : 'Pick target on map' }}
       </button>
-      <button v-if="store.linkTarget" type="button" class="btn btn-secondary btn-sm" @click="store.clearLink()">
+      <button v-if="store.linkTarget" type="button" class="mt-btn mt-btn-secondary mt-btn-sm" @click="store.clearLink()">
         Clear
       </button>
     </div>
 
-    <div v-if="store.linkTarget" class="row g-2 mt-2">
-      <div class="col-6">
-        <label for="tgt_lat" class="form-label">Target lat</label>
-        <input id="tgt_lat" v-model.number="tLat" @change="applyCoords" type="number" step="0.000001"
-          min="-90" max="90" class="form-control form-control-sm" />
+    <div v-if="store.linkTarget" class="mt-2 grid grid-cols-2 gap-2">
+      <div>
+        <label for="tgt_lat" class="mt-label">Target lat</label>
+        <input id="tgt_lat" v-model.number="tLat" @change="applyCoords" type="number" step="0.000001" min="-90" max="90" class="mt-input" />
       </div>
-      <div class="col-6">
-        <label for="tgt_lon" class="form-label">Target lon</label>
-        <input id="tgt_lon" v-model.number="tLon" @change="applyCoords" type="number" step="0.000001"
-          min="-180" max="180" class="form-control form-control-sm" />
+      <div>
+        <label for="tgt_lon" class="mt-label">Target lon</label>
+        <input id="tgt_lon" v-model.number="tLon" @change="applyCoords" type="number" step="0.000001" min="-180" max="180" class="mt-input" />
       </div>
     </div>
 
-    <p v-if="!store.linkTarget && store.linkState !== 'placing'" class="mt-section-hint mt-2 mb-0">
+    <p v-if="!store.linkTarget && store.linkState !== 'placing'" class="mt-hint mt-2">
       Tip: drag the blue target pin to move it; the link recomputes automatically.
     </p>
 
-    <div v-if="store.linkState === 'computing'" class="d-flex align-items-center gap-2 mt-3 small text-secondary">
-      <span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span>
+    <div v-if="store.linkState === 'computing'" class="mt-3 flex items-center gap-2 text-sm text-ink-muted">
+      <span class="mt-spinner" role="status" aria-hidden="true"></span>
       Computing link…
     </div>
 
-    <div v-if="store.linkState === 'error'" class="mt-alert-error mt-3 p-2 small" role="alert">
+    <div v-if="store.linkState === 'error'" class="mt-3 rounded-lg border border-danger bg-danger-bg p-2 text-sm text-on-danger-bg" role="alert">
       {{ store.linkError }}
     </div>
 
@@ -68,7 +69,7 @@
         <span>target</span>
       </div>
 
-      <button type="button" class="btn btn-secondary btn-sm w-100 mt-2" @click="store.computeLink()">
+      <button type="button" class="mt-btn mt-btn-secondary mt-btn-sm mt-2 w-full" @click="store.computeLink()">
         Recompute with current settings
       </button>
     </div>
@@ -129,7 +130,7 @@ const verdictText = computed(() => {
 });
 
 /* Profile chart geometry: terrain (curvature-adjusted), the line-of-sight ray,
- * and the bottom of the first Fresnel zone, scaled into a fixed viewBox. */
+   and the bottom of the first Fresnel zone, scaled into a fixed viewBox. */
 const chart = computed(() => {
   const a = store.linkAnalysis;
   if (!a || a.samples.length < 2) return null;

--- a/src/components/Receiver.vue
+++ b/src/components/Receiver.vue
@@ -1,35 +1,28 @@
-
 <template>
-    <form novalidate>
-        <p class="mt-section-hint mb-2">The nodes that should hear this site (-130 dBm matches the default LongFast preset).</p>
-        <div class="row g-2">
-            <div class="col-6">
-                <label for="rx_sensitivity" class="form-label">Sensitivity (dBm)</label>
-                <input v-model="receiver.rx_sensitivity" type="number" class="form-control form-control-sm" id="rx_sensitivity" required step="1" min="-150" max="-30" />
-            <div class="invalid-feedback">Please enter a valid sensitivity.</div>
-            </div>
-                <div class="col-6">
-                <label for="rx_height" class="form-label">Height AGL (m)</label>
-                <input v-model="receiver.rx_height" type="number" class="form-control form-control-sm" id="rx_height" required min="0" step="0.1" />
-                <div class="invalid-feedback">Height must be a positive number.</div>
-                </div>
-            </div>
-            <div class="row g-2 mt-2">
-                <div class="col-6">
-                <label for="rx_gain" class="form-label">Antenna Gain (dBi)</label>
-                <input v-model="receiver.rx_gain" type="number" class="form-control form-control-sm" id="rx_gain" required min="0" max="30" step="0.1" />
-                <div class="invalid-feedback">Gain must be a positive number.</div>
-            </div>
-            <div class="col-6">
-                <label for="rx_loss" class="form-label">Cable Loss (dB)</label>
-                <input v-model="receiver.rx_loss" type="number" class="form-control form-control-sm" id="rx_loss" required min="0" max="100" step="0.1" />
-                <div class="invalid-feedback">Loss must be a positive number.</div>
-            </div>
-        </div>
-    </form>
+  <div>
+    <p class="mt-hint mb-3">The nodes that should hear this site (-130 dBm matches the default LongFast preset).</p>
+    <div class="grid grid-cols-2 gap-2">
+      <div>
+        <label for="rx_sensitivity" class="mt-label">Sensitivity (dBm)</label>
+        <input v-model="receiver.rx_sensitivity" type="number" class="mt-input" id="rx_sensitivity" step="1" min="-150" max="-30" />
+      </div>
+      <div>
+        <label for="rx_height" class="mt-label">Height AGL (m)</label>
+        <input v-model="receiver.rx_height" type="number" class="mt-input" id="rx_height" min="0" step="0.1" />
+      </div>
+      <div>
+        <label for="rx_gain" class="mt-label">Antenna Gain (dBi)</label>
+        <input v-model="receiver.rx_gain" type="number" class="mt-input" id="rx_gain" min="0" max="30" step="0.1" />
+      </div>
+      <div>
+        <label for="rx_loss" class="mt-label">Cable Loss (dB)</label>
+        <input v-model="receiver.rx_loss" type="number" class="mt-input" id="rx_loss" min="0" max="100" step="0.1" />
+      </div>
+    </div>
+  </div>
 </template>
 
 <script setup lang="ts">
-    import { useStore } from '../store.ts'
-    const receiver = useStore().splatParams.receiver
+import { useStore } from '../store.ts';
+const receiver = useStore().splatParams.receiver;
 </script>

--- a/src/components/Simulation.vue
+++ b/src/components/Simulation.vue
@@ -1,40 +1,34 @@
 <template>
-  <form novalidate>
-        <p class="mt-section-hint mb-2">Statistical confidence and the maximum range to compute. Longer ranges take longer.</p>
-        <div class="row g-2">
-            <div class="col-6">
-                <label for="situation_fraction" class="form-label">Situation Fraction (%)</label>
-                <input v-model="simulation.situation_fraction" type="number" class="form-control form-control-sm" id="situation_fraction" required min="1" max="100" step="0.1" />
-                <div class="invalid-feedback">Percentage must be between 1 and 100 (default: 50).</div>
-            </div>
-            <div class="col-6">
-                <label for="time_fraction" class="form-label">Time Fraction (%)</label>
-                <input v-model="simulation.time_fraction" type="number" class="form-control form-control-sm" id="time_fraction" required min="1" max="100" step="0.1" />
-                <div class="invalid-feedback">Percentage must be between 1 and 100 (default: 90).</div>
-            </div>
-        </div>
-        <div class="row g-2 mt-2">
-            <div class="col-6">
-                <label for="simulation_extent" class="form-label">Max Range (km)</label>
-                <input v-model="simulation.simulation_extent" type="number" class="form-control form-control-sm" id="simulation_extent" required min="1" :max="simulation.high_resolution ? 70 : 150" step="1" />
-                <div class="invalid-feedback">Radius must be a positive number (default: 30 km).</div>
-            </div>
-        </div>
-        <div class="row g-2 mt-3">
-            <div class="col-12">
-                <div class="form-check form-switch">
-                    <input v-model="simulation.high_resolution" type="checkbox" role="switch" class="form-check-input" id="high_resolution" />
-                    <label class="form-check-label" for="high_resolution">High resolution terrain (30 m)</label>
-                </div>
-                <p class="mt-section-hint mt-1 mb-0">
-                    9x more detail than the default 90 m grid. Slower and limited to a 70 km range.
-                </p>
-            </div>
-        </div>
-    </form>
+  <div>
+    <p class="mt-hint mb-3">Statistical confidence and the maximum range to compute. Longer ranges take longer.</p>
+    <div class="grid grid-cols-2 gap-2">
+      <div>
+        <label for="situation_fraction" class="mt-label">Situation Fraction (%)</label>
+        <input v-model="simulation.situation_fraction" type="number" class="mt-input" id="situation_fraction" min="1" max="100" step="0.1" />
+      </div>
+      <div>
+        <label for="time_fraction" class="mt-label">Time Fraction (%)</label>
+        <input v-model="simulation.time_fraction" type="number" class="mt-input" id="time_fraction" min="1" max="100" step="0.1" />
+      </div>
+      <div class="col-span-2">
+        <label for="simulation_extent" class="mt-label">Max Range (km)</label>
+        <input v-model="simulation.simulation_extent" type="number" class="mt-input" id="simulation_extent" min="1" :max="simulation.high_resolution ? 70 : 150" step="1" />
+      </div>
+    </div>
+
+    <label class="mt-3 flex cursor-pointer items-center gap-3">
+      <span class="relative inline-flex shrink-0">
+        <input v-model="simulation.high_resolution" type="checkbox" class="peer sr-only" id="high_resolution" />
+        <span class="block h-5 w-9 rounded-full bg-surface-3 transition-colors peer-checked:bg-primary"></span>
+        <span class="absolute top-0.5 left-0.5 size-4 rounded-full bg-ink transition-transform peer-checked:translate-x-4"></span>
+      </span>
+      <span class="text-sm font-medium text-ink">High resolution terrain (30 m)</span>
+    </label>
+    <p class="mt-hint mt-1">9x more detail than the default 90 m grid. Slower and limited to a 70 km range.</p>
+  </div>
 </template>
 
 <script setup lang="ts">
-import { useStore } from '../store.ts'
-const simulation = useStore().splatParams.simulation
+import { useStore } from '../store.ts';
+const simulation = useStore().splatParams.simulation;
 </script>

--- a/src/components/Transmitter.vue
+++ b/src/components/Transmitter.vue
@@ -1,121 +1,111 @@
-
 <template>
-    <form novalidate>
-        <p class="mt-section-hint mb-2">The radio whose coverage is simulated.</p>
-        <div class="row g-2">
-            <div class="col-12">
-                <label for="name" class="form-label">Site name</label>
-                <input v-model="transmitter.name" class="form-control form-control-sm" id="name" required data-bs-toggle="tooltip" title="Site Name" />
-            </div>
-        </div>
-        <div class="row g-2">
-            <div class="col-6">
-                <label for="tx_lat" class="form-label">Latitude (degrees)</label>
-                <input v-model="transmitter.tx_lat" type="number" class="form-control form-control-sm" id="tx_lat" required min="-90" max="90" step="0.000001" data-bs-toggle="tooltip" title="Transmitter latitude in degrees (-90 to 90)." />
-                <div class="invalid-feedback">Please enter a valid latitude (-90 to 90).</div>
-            </div>
-            <div class="col-6">
-                <label for="tx_lon" class="form-label">Longitude (degrees)</label>
-                <input v-model="transmitter.tx_lon" type="number" class="form-control form-control-sm" id="tx_lon" required min="-180" max="180" step="0.000001" data-bs-toggle="tooltip" title="Transmitter longitude in degrees (-180 to 180)." />
-                <div class="invalid-feedback">Please enter a valid longitude (-180 to 180).</div>
-            </div>
-        </div>
-        <div class="row g-2 mt-2">
-            <div class="col-12">
-                <label for="device" class="form-label">Device (optional)</label>
-                <select v-model="selectedDevice" @change="applyDevice" class="form-select form-select-sm" id="device" data-bs-toggle="tooltip" title="Prefill power and stock-antenna gain from a common Meshtastic device.">
-                    <option value="">Custom / manual</option>
-                    <option v-for="(d, i) in DEVICE_PROFILES" :key="i" :value="i">{{ d.label }}</option>
-                </select>
-                <p class="mt-section-hint mt-1 mb-0">Fills typical power &amp; stock-antenna gain. Tune for your antenna and region.</p>
-            </div>
-        </div>
-        <div class="row g-2 mt-2">
-            <div class="col-6">
-                <label for="tx_power" class="form-label">Power (W)</label>
-                <input v-model="transmitter.tx_power" type="number" class="form-control form-control-sm" id="tx_power" required min="0" step="0.1" data-bs-toggle="tooltip" title="Transmitter power in watts (>0)." />
-                <div class="invalid-feedback">Power must be a positive number.</div>
-            </div>
-            <div class="col-6">
-                <label for="frequency" class="form-label">Frequency (MHz)</label>
-                <input v-model="transmitter.tx_freq" type="number" class="form-control form-control-sm" id="tx_freq" required min="20" max="20000" step="0.1" data-bs-toggle="tooltip" title="Transmitter frequency in MHz (20 to 20,000)." />
-                <div class="invalid-feedback">Frequency must be a positive number.</div>
-            </div>
-        </div>
-        <div class="row g-2 mt-2">
-            <div class="col-6">
-                <label for="tx_height" class="form-label">Height AGL (m)</label>
-                <input v-model="transmitter.tx_height" type="number" class="form-control form-control-sm" id="tx_height" required min="1.0" step="0.1" data-bs-toggle="tooltip" title="Transmitter height above ground in meters (>= 1.0)." />
-                <div class="invalid-feedback">Height must be a positive number.</div>
-            </div>
-            <div class="col-6">
-                <label for="tx_gain" class="form-label">Antenna Gain (dBi)</label>
-                <input v-model="transmitter.tx_gain" type="number" class="form-control form-control-sm" id="tx_gain" required min="0" step="0.1" />
-                <div class="invalid-feedback">Gain must be a positive number.</div>
-            </div>
-        </div>
-        <div class="mt-3 d-flex gap-2">
-            <button @click="store.beginPlaceOnMap()" type="button" id="setWithMap"
-                class="btn btn-sm text-nowrap flex-fill"
-                :class="store.placingMode ? 'btn-secondary active' : 'btn-primary'">
-                {{ store.placingMode ? 'Click the map…' : 'Place on map' }}
-            </button>
-            <button @click="centerMapOnTransmitter" type="button" class="btn btn-secondary btn-sm text-nowrap flex-fill">Center on site</button>
-        </div>
-        <p class="mt-section-hint mt-2 mb-0">Tip: drag the green pin to fine-tune, or type coordinates above.</p>
-    </form>
+  <div>
+    <p class="mt-hint mb-3">The radio whose coverage is simulated.</p>
+    <div class="grid grid-cols-2 gap-2">
+      <div class="col-span-2">
+        <label for="name" class="mt-label">Site name</label>
+        <input v-model="transmitter.name" class="mt-input" id="name" title="Site name" />
+      </div>
+      <div>
+        <label for="tx_lat" class="mt-label">Latitude (degrees)</label>
+        <input v-model="transmitter.tx_lat" type="number" class="mt-input" id="tx_lat" min="-90" max="90" step="0.000001" title="Transmitter latitude in degrees (-90 to 90)." />
+      </div>
+      <div>
+        <label for="tx_lon" class="mt-label">Longitude (degrees)</label>
+        <input v-model="transmitter.tx_lon" type="number" class="mt-input" id="tx_lon" min="-180" max="180" step="0.000001" title="Transmitter longitude in degrees (-180 to 180)." />
+      </div>
+      <div class="col-span-2">
+        <label for="device" class="mt-label">Device (optional)</label>
+        <select v-model="selectedDevice" @change="applyDevice" class="mt-select" id="device" title="Prefill power and stock-antenna gain from a common Meshtastic device.">
+          <option value="">Custom / manual</option>
+          <option v-for="(d, i) in DEVICE_PROFILES" :key="i" :value="i">{{ d.label }}</option>
+        </select>
+        <p class="mt-hint mt-1">Fills typical power &amp; stock-antenna gain. Tune for your antenna and region.</p>
+      </div>
+      <div>
+        <label for="tx_power" class="mt-label">Power (W)</label>
+        <input v-model="transmitter.tx_power" type="number" class="mt-input" id="tx_power" min="0" step="0.1" title="Transmitter power in watts (>0)." />
+      </div>
+      <div>
+        <label for="tx_freq" class="mt-label">Frequency (MHz)</label>
+        <input v-model="transmitter.tx_freq" type="number" class="mt-input" id="tx_freq" min="20" max="20000" step="0.1" title="Transmitter frequency in MHz (20 to 20,000)." />
+      </div>
+      <div>
+        <label for="tx_height" class="mt-label">Height AGL (m)</label>
+        <input v-model="transmitter.tx_height" type="number" class="mt-input" id="tx_height" min="1.0" step="0.1" title="Transmitter height above ground in meters (>= 1.0)." />
+      </div>
+      <div>
+        <label for="tx_gain" class="mt-label">Antenna Gain (dBi)</label>
+        <input v-model="transmitter.tx_gain" type="number" class="mt-input" id="tx_gain" min="0" step="0.1" />
+      </div>
+    </div>
+    <div class="mt-3 flex gap-2">
+      <button
+        @click="store.beginPlaceOnMap()"
+        type="button"
+        id="setWithMap"
+        class="mt-btn mt-btn-sm flex-1 whitespace-nowrap"
+        :class="store.placingMode ? 'mt-btn-secondary' : 'mt-btn-primary'"
+      >
+        {{ store.placingMode ? 'Click the map…' : 'Place on map' }}
+      </button>
+      <button @click="centerMapOnTransmitter" type="button" class="mt-btn mt-btn-secondary mt-btn-sm flex-1 whitespace-nowrap">
+        Center on site
+      </button>
+    </div>
+    <p class="mt-hint mt-2">Tip: drag the green pin to fine-tune, or type coordinates above.</p>
+  </div>
 </template>
 
 <script setup lang="ts">
-    import { useStore } from '../store.ts'
-    import { onMounted, watch, ref } from 'vue';
-    import { DEVICE_PROFILES } from '../deviceProfiles';
-    const store = useStore();
-    const transmitter = store.splatParams.transmitter;
+import { useStore } from '../store.ts';
+import { onMounted, watch, ref } from 'vue';
+import { DEVICE_PROFILES } from '../deviceProfiles';
+const store = useStore();
+const transmitter = store.splatParams.transmitter;
 
-    // Optional device quick-fill (#51): selecting a radio prefills power + gain.
-    const selectedDevice = ref<number | ''>('');
-    function applyDevice() {
-        if (selectedDevice.value === '') return;
-        const d = DEVICE_PROFILES[selectedDevice.value as number];
-        if (!d) return;
-        transmitter.tx_power = d.tx_power;
-        transmitter.tx_gain = d.tx_gain;
-    }
+// Optional device quick-fill (#51): selecting a radio prefills power + gain.
+const selectedDevice = ref<number | ''>('');
+function applyDevice() {
+  if (selectedDevice.value === '') return;
+  const d = DEVICE_PROFILES[selectedDevice.value as number];
+  if (!d) return;
+  transmitter.tx_power = d.tx_power;
+  transmitter.tx_gain = d.tx_gain;
+}
 
-    // If power or gain is hand-edited away from the chosen device, fall back to
-    // "Custom" so the dropdown never misrepresents the current values.
-    watch(
-        () => [Number(transmitter.tx_power), Number(transmitter.tx_gain)] as const,
-        ([p, g]) => {
-            if (selectedDevice.value === '') return;
-            const d = DEVICE_PROFILES[selectedDevice.value as number];
-            if (d && (p !== d.tx_power || g !== d.tx_gain)) selectedDevice.value = '';
-        }
-    );
+// If power or gain is hand-edited away from the chosen device, fall back to
+// "Custom" so the dropdown never misrepresents the current values.
+watch(
+  () => [Number(transmitter.tx_power), Number(transmitter.tx_gain)] as const,
+  ([p, g]) => {
+    if (selectedDevice.value === '') return;
+    const d = DEVICE_PROFILES[selectedDevice.value as number];
+    if (d && (p !== d.tx_power || g !== d.tx_gain)) selectedDevice.value = '';
+  }
+);
 
-    const centerMapOnTransmitter = () => {
-        if (!isNaN(transmitter.tx_lat) && !isNaN(transmitter.tx_lon)) {
-            store.getMap()?.flyTo({ center: [transmitter.tx_lon, transmitter.tx_lat] });
-        } else {
-            alert("Please enter valid Latitude and Longitude values.");
-        }
-    };
+const centerMapOnTransmitter = () => {
+  if (!isNaN(transmitter.tx_lat) && !isNaN(transmitter.tx_lon)) {
+    store.getMap()?.flyTo({ center: [transmitter.tx_lon, transmitter.tx_lat] });
+  } else {
+    alert('Please enter valid Latitude and Longitude values.');
+  }
+};
 
-    // Typing coordinates moves (or creates) the draggable draft pin, so the
-    // text fields and the map marker always agree. Skipped mid-simulation.
-    watch(
-        () => [Number(transmitter.tx_lat), Number(transmitter.tx_lon)] as const,
-        ([lat, lon]) => {
-            if (store.simulationState === 'running') return;
-            if (!Number.isFinite(lat) || !Number.isFinite(lon)) return;
-            if (lat < -90 || lat > 90 || lon < -180 || lon > 180) return;
-            store.setDraftMarker(lat, lon);
-        }
-    );
+// Typing coordinates moves (or creates) the draggable draft pin, so the
+// text fields and the map marker always agree. Skipped mid-simulation.
+watch(
+  () => [Number(transmitter.tx_lat), Number(transmitter.tx_lon)] as const,
+  ([lat, lon]) => {
+    if (store.simulationState === 'running') return;
+    if (!Number.isFinite(lat) || !Number.isFinite(lon)) return;
+    if (lat < -90 || lat > 90 || lon < -180 || lon > 180) return;
+    store.setDraftMarker(lat, lon);
+  }
+);
 
-    onMounted(() => {
-        store.initMap(); // Initialize the map
-    });
-
+onMounted(() => {
+  store.initMap(); // Initialize the map
+});
 </script>

--- a/src/components/ui/AppDrawer.vue
+++ b/src/components/ui/AppDrawer.vue
@@ -1,0 +1,38 @@
+<!-- Right-hand slide-over panel (replaces the Bootstrap offcanvas). A flex
+     column: fixed header, scrollable body (default slot), and an optional
+     sticky footer slot used for the always-visible Run action. -->
+<template>
+  <aside
+    class="fixed top-[57px] right-0 z-[1000] flex h-[calc(100dvh-57px)] w-[380px] max-w-[92vw] flex-col border-l border-line bg-canvas shadow-2xl transition-transform duration-300 ease-out"
+    :class="modelValue ? 'translate-x-0' : 'translate-x-full'"
+    :aria-hidden="!modelValue"
+    aria-label="Site parameters"
+  >
+    <header class="flex items-center justify-between border-b border-line px-4 py-3">
+      <h2 class="m-0 text-base font-bold text-ink">{{ title }}</h2>
+      <button
+        type="button"
+        class="grid size-8 place-items-center rounded-lg text-ink-muted transition hover:bg-surface-2 hover:text-ink"
+        aria-label="Close panel"
+        @click="emit('update:modelValue', false)"
+      >
+        <svg viewBox="0 0 24 24" class="size-5" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
+          <path d="m6 6 12 12M18 6 6 18" />
+        </svg>
+      </button>
+    </header>
+
+    <div class="flex-1 space-y-3 overflow-y-auto px-4 py-4 [scrollbar-color:var(--mt-outline-variant)_transparent] [scrollbar-width:thin]">
+      <slot />
+    </div>
+
+    <footer v-if="$slots.footer" class="border-t border-line bg-canvas/95 px-4 py-3 backdrop-blur">
+      <slot name="footer" />
+    </footer>
+  </aside>
+</template>
+
+<script setup lang="ts">
+defineProps<{ modelValue: boolean; title: string }>();
+const emit = defineEmits<{ 'update:modelValue': [boolean] }>();
+</script>

--- a/src/components/ui/MapLegend.vue
+++ b/src/components/ui/MapLegend.vue
@@ -1,0 +1,34 @@
+<!-- On-map coverage legend (#2): a persistent key for the heatmap/contour
+     colours so the scale is readable without opening the Display panel. Driven
+     by the most-recently-added visible site (each site keeps its own scale). -->
+<template>
+  <div
+    v-if="active"
+    class="fixed bottom-3 left-14 z-[500] rounded-xl border border-line bg-canvas/90 px-3 py-2 shadow-2xl backdrop-blur-sm"
+  >
+    <div class="mb-1 flex items-center justify-between gap-3">
+      <span class="text-[0.6875rem] font-bold tracking-wider text-ink-muted uppercase">Signal</span>
+      <span class="text-[0.6875rem] font-semibold text-ink-muted">{{ styleLabel }}</span>
+    </div>
+    <img :src="colorbarSrc" alt="" class="mt-colorbar !h-3 w-40" />
+    <div class="mt-1 flex justify-between text-[0.6875rem] font-semibold text-ink-muted tabular-nums">
+      <span>{{ active.min_dbm }} dBm</span>
+      <span>{{ active.max_dbm }} dBm</span>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue';
+import { useStore } from '../../store.ts';
+
+const store = useStore();
+
+const active = computed(() => {
+  const visible = store.localSites.filter((s) => s.visible !== false && s.result);
+  return visible.length ? visible[visible.length - 1].params.display : null;
+});
+
+const colorbarSrc = computed(() => `${import.meta.env.BASE_URL}colormaps/${active.value?.color_scale}.png`);
+const styleLabel = computed(() => (store.overlayStyle === 'contours' ? 'Contours' : 'Heatmap'));
+</script>

--- a/src/components/ui/Section.vue
+++ b/src/components/ui/Section.vue
@@ -1,0 +1,39 @@
+<!-- Collapsible parameter section (replaces the Bootstrap accordion). Each
+     section owns its open state, so several can be open at once. Content stays
+     mounted (v-show) — child onMounted hooks like the map init must persist. -->
+<template>
+  <section class="overflow-hidden rounded-xl border border-line bg-surface/40">
+    <h2 class="m-0">
+      <button
+        type="button"
+        class="flex min-h-[44px] w-full items-center justify-between gap-2 px-4 py-3 text-left text-[0.9375rem] font-semibold transition"
+        :class="open ? 'text-primary' : 'text-ink hover:bg-surface-2'"
+        :aria-expanded="open"
+        @click="open = !open"
+      >
+        <span>{{ title }}</span>
+        <svg
+          class="size-4 shrink-0 transition-transform duration-200"
+          :class="open ? 'rotate-180 text-primary' : 'text-ink-muted'"
+          viewBox="0 0 16 16"
+          fill="currentColor"
+          aria-hidden="true"
+        >
+          <path
+            fill-rule="evenodd"
+            d="M1.646 4.646a.5.5 0 0 1 .708 0L8 10.293l5.646-5.647a.5.5 0 0 1 .708.708l-6 6a.5.5 0 0 1-.708 0l-6-6a.5.5 0 0 1 0-.708z"
+          />
+        </svg>
+      </button>
+    </h2>
+    <div v-show="open" class="border-t border-line px-4 py-4">
+      <slot />
+    </div>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue';
+const props = defineProps<{ title: string; defaultOpen?: boolean }>();
+const open = ref(props.defaultOpen ?? false);
+</script>

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,4 @@
 import { createApp } from 'vue'
-// Import order matters: the theme in style.css overrides Bootstrap.
-import 'bootstrap/dist/css/bootstrap.min.css'
 import 'maplibre-gl/dist/maplibre-gl.css'
 import './style.css'
 import App from './App.vue'

--- a/src/store.ts
+++ b/src/store.ts
@@ -426,6 +426,16 @@ const useStore = defineStore('store', {
       this.overlayStyle = style;
       this.syncOverlays();
     },
+    /** Live-apply the Display panel to every existing overlay without
+     * recomputing (#1). The engine output is cached per site, so re-coloring
+     * (and re-thresholding/opacity) is a pure re-render — instant even after a
+     * slow HD run. Mirrors the panel onto each site so the list swatches and
+     * the on-map legend stay in sync. */
+    applyDisplayLive() {
+      const d = this.splatParams.display;
+      for (const site of this.localSites) Object.assign(site.params.display, d);
+      this.syncOverlays();
+    },
     /** (Re-)adds every site's overlay in the current style; safe after
      * style switches and idempotent. */
     syncOverlays() {

--- a/src/style.css
+++ b/src/style.css
@@ -1,17 +1,13 @@
+@import 'tailwindcss';
+
 /* Meshtastic Site Planner theme.
  *
- * Implements the Meshtastic Client Design Standards v1.4
- * (https://github.com/meshtastic/design, standards/), dark scheme:
- * tokens below are the documented dark-mode Material role mapping built
- * from the brand palette (Neutral #2C2D3C scale, Green #67EA94 scale).
- * Typography follows the native-OS-familiarity principle (system stack,
- * 16px base), touch targets are >= 44px on primary actions, and all
- * pairings below hold WCAG AA 4.5:1 contrast.
- */
-
-:root,
-[data-bs-theme='dark'] {
-  /* --- Meshtastic dark scheme tokens (design standards v1.4, s8.3) --- */
+ * Implements the Meshtastic Client Design Standards v1.4 (dark scheme):
+ * the --mt-* custom properties below are the documented dark-mode Material
+ * role mapping built from the brand palette (Neutral #2C2D3C scale,
+ * Green #67EA94 scale) and remain the single source of truth. They are
+ * surfaced to Tailwind utilities via the @theme block. */
+:root {
   --mt-primary: #67ea94; /* Green 500 */
   --mt-on-primary: #0f1017; /* Neutral 950 */
   --mt-primary-container: #2d8f52; /* Green 700 */
@@ -35,16 +31,40 @@
   --mt-surface-container: #242533;
   --mt-surface-container-high: #2c2d3c; /* Neutral 800 (brand primary) */
   --mt-surface-container-highest: #3d3e50;
+}
 
-  /* --- Bootstrap 5.3 bridge --- */
-  --bs-body-bg: var(--mt-background);
-  --bs-body-color: var(--mt-on-background);
-  --bs-body-font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto,
+/* Expose the brand tokens as Tailwind theme colors so utilities like
+ * `bg-surface-2`, `text-ink-muted`, `border-line`, `text-primary` work and
+ * support opacity modifiers (Tailwind v4 mixes via color-mix). */
+@theme {
+  --font-sans: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto,
     'Helvetica Neue', Arial, 'Noto Sans', sans-serif;
-  --bs-body-font-size: 1rem; /* 16px default per standards */
-  --bs-border-color: var(--mt-outline-variant);
-  --bs-link-color: var(--mt-tertiary);
-  --bs-link-hover-color: #d0d8f5; /* Blue 200 */
+
+  --color-sunken: var(--mt-surface-container-lowest); /* #0f1017 */
+  --color-canvas: var(--mt-background); /* #1a1b26 */
+  --color-surface: var(--mt-surface-container); /* #242533 */
+  --color-surface-2: var(--mt-surface-container-high); /* #2c2d3c */
+  --color-surface-3: var(--mt-surface-container-highest); /* #3d3e50 */
+
+  --color-ink: var(--mt-on-surface); /* #ecedf3 */
+  --color-ink-muted: var(--mt-on-surface-variant); /* #bdbfcf */
+
+  --color-line: var(--mt-outline-variant); /* #444660 */
+  --color-line-strong: var(--mt-outline); /* #767892 */
+
+  --color-primary: var(--mt-primary); /* #67ea94 */
+  --color-on-primary: var(--mt-on-primary); /* #0f1017 */
+  --color-primary-hi: #8ff0b2; /* Green 400 */
+  --color-primary-lo: #3fb86d; /* Green 600 */
+
+  --color-tonal: var(--mt-secondary-container); /* #3d3e50 */
+  --color-on-tonal: var(--mt-on-secondary-container); /* #d5d6e0 */
+
+  --color-info: var(--mt-tertiary); /* #b0bff0 */
+
+  --color-danger: var(--mt-error); /* #ffb4ab */
+  --color-danger-bg: var(--mt-error-container); /* #93000a */
+  --color-on-danger-bg: var(--mt-on-error-container); /* #ffdad6 */
 }
 
 html,
@@ -54,325 +74,97 @@ body {
   padding: 0;
 }
 
+body {
+  background: var(--mt-background);
+  color: var(--mt-on-background);
+  font-family: var(--font-sans);
+  font-size: 16px;
+}
+
 #map {
+  position: absolute;
+  inset: 0;
   height: 100vh;
   margin: 0;
   padding: 0;
   background: var(--mt-surface-container-lowest);
 }
 
-/* ---------- App header ---------- */
+/* ---------- Reusable form + button primitives ---------- */
 
-.mt-navbar {
-  background: var(--mt-surface-container-lowest);
-  border-bottom: 1px solid var(--mt-outline-variant);
+@layer components {
+  .mt-label {
+    @apply mb-1 block text-[0.8125rem] font-semibold text-ink-muted;
+  }
+
+  .mt-hint {
+    @apply text-[0.8125rem] leading-snug text-ink-muted;
+  }
+
+  .mt-input,
+  .mt-select {
+    @apply w-full rounded-lg border border-line bg-surface-2 px-3 py-2 text-sm text-ink shadow-sm transition;
+    @apply outline-none focus:border-primary focus:ring-2 focus:ring-primary/30;
+  }
+
+  .mt-input::placeholder {
+    color: var(--mt-on-surface-variant);
+  }
+
+  .mt-select {
+    @apply cursor-pointer appearance-none bg-no-repeat pr-9;
+    background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3e%3cpath fill='none' stroke='%23bdbfcf' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='m2 5 6 6 6-6'/%3e%3c/svg%3e");
+    background-position: right 0.625rem center;
+    background-size: 14px 14px;
+  }
+
+  .mt-select option {
+    background: var(--mt-surface-container-high);
+    color: var(--mt-on-surface);
+  }
+
+  .mt-btn {
+    @apply inline-flex min-h-[40px] items-center justify-center gap-2 rounded-lg px-3.5 py-2 text-sm font-semibold transition select-none;
+    @apply focus-visible:ring-2 focus-visible:ring-primary/40 focus-visible:outline-none;
+    @apply disabled:cursor-not-allowed disabled:opacity-50;
+  }
+
+  .mt-btn-sm {
+    @apply min-h-[34px] px-2.5 py-1.5 text-[0.8125rem];
+  }
+
+  .mt-btn-primary {
+    @apply bg-primary text-on-primary hover:bg-primary-hi active:bg-primary-lo;
+  }
+
+  .mt-btn-secondary {
+    @apply bg-tonal text-on-tonal hover:bg-surface-3;
+  }
+
+  .mt-btn-ghost {
+    @apply border border-line-strong text-ink hover:bg-surface-2;
+  }
+
+  /* Slim loading spinner (replaces Bootstrap's .spinner-border). */
+  .mt-spinner {
+    @apply inline-block size-4 animate-spin rounded-full border-2 border-current border-r-transparent align-[-0.125em];
+  }
+
+  /* Coverage colour-scale legend (Display panel + on-map legend). */
+  .mt-colorbar {
+    @apply block h-6 w-full rounded border border-line;
+  }
+
+  .mt-legend-label {
+    @apply rounded bg-surface-3 px-2 py-0.5 text-xs font-semibold text-ink;
+  }
 }
 
-.mt-navbar .navbar-brand {
-  color: var(--mt-on-background);
-  font-weight: 650;
-  letter-spacing: 0.01em;
-  display: flex;
-  align-items: center;
-  gap: 0.625rem;
-}
-
-.mt-brand-badge {
-  color: var(--mt-on-surface-variant);
-  font-size: 0.75rem;
-  font-weight: 500;
-  border: 1px solid var(--mt-outline-variant);
-  border-radius: 999px;
-  padding: 0.125rem 0.625rem;
-  white-space: nowrap;
-}
-
-.mt-brand-badge .mt-dot {
-  display: inline-block;
-  width: 0.5rem;
-  height: 0.5rem;
-  border-radius: 50%;
-  background: var(--mt-primary);
-  margin-right: 0.375rem;
-}
-
-/* ---------- Sidebar / parameters panel ---------- */
-
-/* Sits below the fixed navbar so the brand and toggler stay reachable.
- * (.offcanvas.mt-sidebar out-specifies Bootstrap's .offcanvas.offcanvas-end.) */
-.offcanvas.mt-sidebar {
-  background: var(--mt-surface-container-low);
-  color: var(--mt-on-surface);
-  border-left: 1px solid var(--mt-outline-variant);
-  width: 380px;
-  max-width: 92vw;
-  top: 57px;
-  height: calc(100% - 57px);
-}
-
-.mt-sidebar .offcanvas-header {
-  border-bottom: 1px solid var(--mt-outline-variant);
-}
-
-.mt-sidebar .offcanvas-title {
-  font-size: 1rem;
-  font-weight: 650;
-}
-
-.mt-sidebar .offcanvas-body {
-  scrollbar-width: thin;
-  scrollbar-color: var(--mt-outline-variant) transparent;
-}
-
-/* ---------- Accordion sections ---------- */
-
-.mt-accordion {
-  --bs-accordion-bg: transparent;
-  --bs-accordion-color: var(--mt-on-surface);
-  --bs-accordion-border-color: var(--mt-outline-variant);
-  --bs-accordion-btn-color: var(--mt-on-surface);
-  --bs-accordion-btn-bg: transparent;
-  --bs-accordion-active-bg: var(--mt-surface-container);
-  --bs-accordion-active-color: var(--mt-primary);
-  --bs-accordion-btn-focus-box-shadow: 0 0 0 0.2rem rgba(103, 234, 148, 0.25);
-  --bs-accordion-btn-padding-y: 0.875rem;
-  --bs-accordion-body-padding-y: 1rem;
-}
-
-.mt-accordion .accordion-button {
-  font-size: 0.9375rem;
-  font-weight: 600;
-  min-height: 44px; /* touch target */
-  color: var(--mt-on-surface);
-  background: transparent;
-  /* Chevron in onSurfaceVariant */
-  --bs-accordion-btn-icon: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='%23bdbfcf'%3e%3cpath fill-rule='evenodd' d='M1.646 4.646a.5.5 0 0 1 .708 0L8 10.293l5.646-5.647a.5.5 0 0 1 .708.708l-6 6a.5.5 0 0 1-.708 0l-6-6a.5.5 0 0 1 0-.708z'/%3e%3c/svg%3e");
-  /* Active chevron in brand green */
-  --bs-accordion-btn-active-icon: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='%2367ea94'%3e%3cpath fill-rule='evenodd' d='M1.646 4.646a.5.5 0 0 1 .708 0L8 10.293l5.646-5.647a.5.5 0 0 1 .708.708l-6 6a.5.5 0 0 1-.708 0l-6-6a.5.5 0 0 1 0-.708z'/%3e%3c/svg%3e");
-}
-
-/* Explicit active state: brand green on a raised surface (Bootstrap's
- * dark theme would otherwise tint these blue). */
-.mt-accordion .accordion-button:not(.collapsed) {
-  color: var(--mt-primary);
-  background-color: var(--mt-surface-container);
-  box-shadow: inset 0 -1px 0 var(--mt-outline-variant);
-}
-
-/* Bootstrap's dark theme re-declares the chevron vars on ::after itself,
- * so repeat the brand icons at that scope. */
-.mt-accordion .accordion-button::after {
-  --bs-accordion-btn-icon: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='%23bdbfcf'%3e%3cpath fill-rule='evenodd' d='M1.646 4.646a.5.5 0 0 1 .708 0L8 10.293l5.646-5.647a.5.5 0 0 1 .708.708l-6 6a.5.5 0 0 1-.708 0l-6-6a.5.5 0 0 1 0-.708z'/%3e%3c/svg%3e");
-  --bs-accordion-btn-active-icon: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='%2367ea94'%3e%3cpath fill-rule='evenodd' d='M1.646 4.646a.5.5 0 0 1 .708 0L8 10.293l5.646-5.647a.5.5 0 0 1 .708.708l-6 6a.5.5 0 0 1-.708 0l-6-6a.5.5 0 0 1 0-.708z'/%3e%3c/svg%3e");
-}
-
-.mt-section-hint {
-  color: var(--mt-on-surface-variant);
-  font-size: 0.8125rem;
-  margin-bottom: 0.75rem;
-}
-
-/* ---------- Forms ---------- */
-
-.form-label {
-  color: var(--mt-on-surface-variant);
-  font-size: 0.8125rem;
-  font-weight: 600;
-  margin-bottom: 0.25rem;
-}
-
-.form-control,
-.form-select {
-  background-color: var(--mt-surface-container-high);
-  border-color: var(--mt-outline-variant);
-  color: var(--mt-on-surface);
-}
-
-.form-control:focus,
-.form-select:focus {
-  background-color: var(--mt-surface-container-high);
-  border-color: var(--mt-primary);
-  color: var(--mt-on-surface);
-  box-shadow: 0 0 0 0.2rem rgba(103, 234, 148, 0.25);
-}
-
-.form-select {
-  /* Bootstrap's dark-mode caret, forced to the variant text color */
-  background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3e%3cpath fill='none' stroke='%23bdbfcf' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='m2 5 6 6 6-6'/%3e%3c/svg%3e");
-}
-
-/* ---------- Buttons ---------- */
-
-.btn {
-  font-weight: 600;
-}
-
-/* Primary action: brand green with dark text (AA on Green 500). */
-.btn-primary {
-  --bs-btn-bg: var(--mt-primary);
-  --bs-btn-border-color: var(--mt-primary);
-  --bs-btn-color: var(--mt-on-primary);
-  --bs-btn-hover-bg: #8ff0b2; /* Green 400 */
-  --bs-btn-hover-border-color: #8ff0b2;
-  --bs-btn-hover-color: var(--mt-on-primary);
-  --bs-btn-active-bg: #3fb86d; /* Green 600 */
-  --bs-btn-active-border-color: #3fb86d;
-  --bs-btn-active-color: var(--mt-on-primary);
-  --bs-btn-disabled-bg: var(--mt-surface-container-highest);
-  --bs-btn-disabled-border-color: var(--mt-surface-container-highest);
-  --bs-btn-disabled-color: var(--mt-on-surface-variant);
-  --bs-btn-focus-shadow-rgb: 103, 234, 148;
-}
-
-/* Secondary action: tonal container per Material role mapping. */
-.btn-secondary {
-  --bs-btn-bg: var(--mt-secondary-container);
-  --bs-btn-border-color: var(--mt-secondary-container);
-  --bs-btn-color: var(--mt-on-secondary-container);
-  --bs-btn-hover-bg: var(--mt-surface-container-highest);
-  --bs-btn-hover-border-color: var(--mt-surface-container-highest);
-  --bs-btn-hover-color: var(--mt-on-surface);
-  --bs-btn-active-bg: var(--mt-surface-container-highest);
-  --bs-btn-active-border-color: var(--mt-outline);
-  --bs-btn-active-color: var(--mt-on-surface);
-  --bs-btn-focus-shadow-rgb: 118, 120, 146;
-}
-
-.btn-outline-light {
-  --bs-btn-color: var(--mt-on-surface);
-  --bs-btn-border-color: var(--mt-outline);
-  --bs-btn-hover-bg: var(--mt-surface-container-highest);
-  --bs-btn-hover-border-color: var(--mt-outline);
-  --bs-btn-hover-color: var(--mt-on-surface);
-  --bs-btn-active-bg: var(--mt-surface-container-highest);
-  --bs-btn-active-border-color: var(--mt-outline);
-  --bs-btn-active-color: var(--mt-on-surface);
-}
-
-.mt-run-btn {
-  min-height: 44px; /* touch target */
-}
-
-/* ---------- Progress ---------- */
-
-.mt-progress {
-  --bs-progress-bg: var(--mt-surface-container-highest);
-  --bs-progress-bar-bg: var(--mt-primary);
-  height: 0.5rem;
-  border-radius: 999px;
-}
-
-.mt-progress-label {
-  color: var(--mt-on-surface-variant);
-  font-size: 0.8125rem;
-}
-
-/* ---------- Error alert ---------- */
-
-.mt-alert-error {
-  background: var(--mt-error-container);
-  border: 1px solid var(--mt-error);
-  color: var(--mt-on-error-container);
-  border-radius: 0.5rem;
-}
-
-/* ---------- Site list ---------- */
-
-.mt-sites-heading {
-  color: var(--mt-on-surface-variant);
-  font-size: 0.75rem;
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-}
-
-/* Standards: list rows keep a neutral background for legibility. */
-.mt-site-list {
-  --bs-list-group-bg: var(--mt-surface-container);
-  --bs-list-group-color: var(--mt-on-surface);
-  --bs-list-group-border-color: var(--mt-outline-variant);
-}
-
-.mt-site-list .list-group-item {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  min-height: 44px;
-}
-
-.mt-site-dot {
-  display: inline-block;
-  width: 0.625rem;
-  height: 0.625rem;
-  border-radius: 50%;
-  background: var(--mt-primary);
-  margin-right: 0.5rem;
-  flex: none;
-}
-
-.mt-site-list .btn-close {
-  filter: invert(1) grayscale(100%) brightness(200%);
-}
-
-/* ---------- Display legend ---------- */
-
-.mt-colorbar {
-  border: 1px solid var(--mt-outline-variant);
-  border-radius: 0.25rem;
-  display: block;
-  margin: 0 auto;
-  width: 100%;
-  max-width: 256px;
-  height: 24px;
-}
-
-.mt-legend-label {
-  background: var(--mt-surface-container-highest);
-  color: var(--mt-on-surface);
-  font-size: 0.75rem;
-  font-weight: 600;
-  border-radius: 0.25rem;
-  padding: 0.125rem 0.5rem;
-}
-
-.mt-site-link {
-  background: none;
-  border: 0;
-  padding: 0;
-  color: var(--mt-on-surface);
-  font: inherit;
-  text-align: left;
-  cursor: pointer;
-  min-height: 44px;
-  display: inline-flex;
-  align-items: center;
-  flex: 1 1 auto;
-  min-width: 0;
-}
-
-.mt-site-link:hover {
-  color: var(--mt-primary);
-}
-
-.mt-site-eye {
-  background: none;
-  border: 0;
-  padding: 0.25rem;
-  margin-right: 0.25rem;
-  color: var(--mt-on-surface-variant);
-  cursor: pointer;
-  display: inline-flex;
-  flex: none;
-}
-
-.mt-site-eye:hover {
-  color: var(--mt-on-surface);
-}
-
-.mt-site-hidden .mt-site-link {
-  color: var(--mt-on-surface-variant);
-  opacity: 0.6;
-}
+/* ===========================================================================
+ * Map UI below is plain CSS: it styles DOM generated by src/map/*.ts and the
+ * marker elements, and MapLibre's own controls. It reads the brand tokens via
+ * var(--mt-*). Do not fold into components/utilities.
+ * ======================================================================== */
 
 /* ---------- Map: popup export ---------- */
 
@@ -410,7 +202,7 @@ body {
 
 /* ---------- Map: place search ---------- */
 
-/* The app navbar (fixed-top, ~57px) overlaps the map's top control corner;
+/* The app navbar (fixed, ~57px) overlaps the map's top control corner;
  * push top-anchored controls below it so the search box is reachable. */
 .maplibregl-ctrl-top-left {
   top: 64px;
@@ -729,7 +521,7 @@ body {
   display: flex;
   align-items: center;
   gap: 0.5rem;
-  border-radius: var(--bs-border-radius, 0.375rem);
+  border-radius: 0.5rem;
   padding: 0.4rem 0.6rem;
   font-size: 0.85rem;
   font-weight: 600;
@@ -798,7 +590,7 @@ body {
   height: 120px;
   background: var(--mt-surface-container-lowest);
   border: 1px solid var(--mt-outline-variant);
-  border-radius: var(--bs-border-radius, 0.375rem);
+  border-radius: 0.5rem;
 }
 
 .mt-link-axis {
@@ -807,10 +599,4 @@ body {
   font-size: 0.75rem;
   color: var(--mt-on-surface-variant);
   margin-top: 0.25rem;
-}
-
-/* ---------- Misc ---------- */
-
-.spinner-border-sm {
-  margin-right: 0.5rem;
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,9 +1,10 @@
 import { defineConfig } from 'vite'
 import vue from '@vitejs/plugin-vue'
+import tailwindcss from '@tailwindcss/vite'
 
 // https://vite.dev/config/
 export default defineConfig(({ command }) => ({
-  plugins: [vue()],
+  plugins: [vue(), tailwindcss()],
   // Relative asset paths in production so the build works unchanged at the
   // default GitHub Pages project URL (…github.io/meshtastic-site-planner/)
   // AND at a custom domain root (site.meshtastic.org). The app has no


### PR DESCRIPTION
Swaps the front end from Bootstrap 5 to **Tailwind v4** with small custom Vue
components, refreshes the look, and folds in three audit items (#1, #2, #5).
The Meshtastic dark/green design tokens are kept as the single source of truth
and surfaced to Tailwind via `@theme`; the map-control styling, marker pin, and
point-to-point chart styles are preserved untouched.

## Framework migration
- **Bootstrap offcanvas → `AppDrawer.vue`** — reactive slide-over. Map-first on
  mobile: the panel starts closed so the map is visible, and opens over a dim
  backdrop (fixes the old behavior where the offcanvas covered the map and
  squeezed the controls into a sliver).
- **Bootstrap accordion → `Section.vue`** — accessible disclosure, multi-open;
  content stays mounted so the map initialization persists.
- **Forms/buttons → `@layer` component classes** (`mt-input`, `mt-select`,
  `mt-btn`, …) so the panels stay readable.
- Removes the Bootstrap JS bundle, the never-initialized tooltip markup, and the
  unused `vue3-popper` dependency.

## Audit follow-ups
- **#1 Live recolor** — editing the Display panel (color scale / min / max /
  transparency) now re-renders existing coverage **instantly** via
  `store.applyDisplayLive()`, with no recompute. Previously changes applied only
  to the next run, which was painful after a multi-minute HD simulation.
- **#2 On-map legend** (`MapLegend.vue`) — a persistent colorbar + dBm range
  pinned over the map, driven by the visible site's scale.
- **#5 Sticky Run** — Run/Cancel + progress + errors live in a pinned drawer
  footer, always visible instead of below the fold.

## Verification
- `vue-tsc` typecheck, **33 tests**, and `vite build` all pass.
- Verified live in the browser at desktop (1440) and mobile (390): run a sim,
  live recolor (plasma → turbo with no recompute), legend, section toggles,
  drawer open/close + backdrop.
- **CSS bundle 315 kB → 105 kB** (44 → 17 kB gzipped); Bootstrap JS removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
