### PR TITLE
Style coverage GeoJSON with simplestyle-spec (fill/stroke)

### DIFF
--- a/src/map/contours.ts
+++ b/src/map/contours.ts
@@ -157,14 +157,32 @@ export function coverageContours(result: CoverageResult, opts: ContourOptions): 
     .map((c) => {
       const t = (c.value - opts.minDbm) / colorSpan;
       const ci = Math.max(0, Math.min(255, Math.round(t * 255))) * 3;
-      const color = `rgb(${lut[ci]}, ${lut[ci + 1]}, ${lut[ci + 2]})`;
+      const r = lut[ci] ?? 0;
+      const g = lut[ci + 1] ?? 0;
+      const b = lut[ci + 2] ?? 0;
+      const color = `rgb(${r}, ${g}, ${b})`;
+      // Hex form of the same color for the simplestyle-spec keys below. The spec — and the renderers
+      // that read it — require hex, not rgb().
+      const hex = `#${[r, g, b].map((v) => v.toString(16).padStart(2, '0')).join('')}`;
       const geometry: MultiPolygon = {
         type: 'MultiPolygon',
         coordinates: c.coordinates.map((poly) => poly.map((ring) => ring.map(toLngLat))),
       };
       return {
         type: 'Feature',
-        properties: { dbm: Math.round(c.value), color, label: `≥ ${Math.round(c.value)} dBm` },
+        properties: {
+          dbm: Math.round(c.value),
+          color,
+          label: `≥ ${Math.round(c.value)} dBm`,
+          // simplestyle-spec (https://github.com/mapbox/simplestyle-spec) so the contours render with
+          // their coverage colors in tools that don't read our custom `color` key — e.g. the
+          // Meshtastic mobile apps' GeoJSON import, geojson.io, and GitHub GeoJSON previews.
+          fill: hex,
+          'fill-opacity': 0.35,
+          stroke: hex,
+          'stroke-width': 1,
+          'stroke-opacity': 0.8,
+        },
         geometry,
       };
     });


### PR DESCRIPTION
## What

Coverage contour features in the GeoJSON export carried only a custom `color` (`rgb(...)`) plus `dbm`/`label`. Renderers that don't read that key drew them unstyled — default stroke, no fill — so the coverage gradient was lost (Meshtastic mobile apps' GeoJSON import, geojson.io, GitHub previews, QGIS symbology).

This emits the same color via [simplestyle-spec](https://github.com/mapbox/simplestyle-spec) keys, as **hex**, alongside the existing properties:

- `fill`, `fill-opacity` (`0.35`), `stroke`, `stroke-width` (`1`), `stroke-opacity` (`0.8`)

`color`/`dbm`/`label` are kept for backward compatibility. Only `src/map/contours.ts` changes.

```jsonc
"properties": {
  "dbm": -110,
  "color": "rgb(0,128,255)",   // unchanged
  "label": "≥ -110 dBm",
  "fill": "#0080ff",           // new — simplestyle
  "fill-opacity": 0.35,
  "stroke": "#0080ff",
  "stroke-width": 1,
  "stroke-opacity": 0.8
}
```

## Why

simplestyle-spec is the de-facto convention that styling-aware GeoJSON renderers read, so exports now render with their coverage colors with no extra configuration — including the Meshtastic iOS app (whose overlay import reads exactly these keys and defaults `fill-opacity` to `0`, which is why the contours previously imported unfilled).

## Notes

- `fill-opacity` is `0.35` so stacked contour bands read as a gradient; easy to tune.
- The KML export already renders styled and is unchanged.

Closes #69


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated contour styling data so map features now include standard fill and stroke properties, improving how contour areas are rendered.
  * Refined color output for contours, including both RGB and hex formats, with safer fallback values when color data is incomplete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->