### PR TITLE
feat(export): send coverage GeoJSON straight to the Meshtastic app

### DIFF
--- a/src/map/export.ts
+++ b/src/map/export.ts
@@ -78,14 +78,52 @@ function worldFile(result: CoverageResult): string {
   return [a, 0, 0, e, c, f].map((n) => n.toString()).join('\n') + '\n';
 }
 
-export function exportGeoJSON(site: Site): void {
-  const fc = coverageContours(site.result, {
+function coverageFeatureCollection(site: Site) {
+  return coverageContours(site.result, {
     colorScale: site.params.display.color_scale,
     minDbm: site.params.display.min_dbm,
     maxDbm: site.params.display.max_dbm,
     sensitivityDbm: site.params.receiver.rx_sensitivity,
   });
+}
+
+export function exportGeoJSON(site: Site): void {
+  const fc = coverageFeatureCollection(site);
   download(`${slug(site.params.transmitter.name)}.geojson`, new Blob([JSON.stringify(fc)], { type: 'application/geo+json' }));
+}
+
+/** True if the browser can hand a file to the OS share sheet (e.g. iOS/Android
+ * "Open in Meshtastic"). Desktop and older mobile browsers report false —
+ * callers should fall back to a plain download. */
+export function canShareFiles(): boolean {
+  if (typeof navigator === 'undefined' || !navigator.canShare) return false;
+  const probe = new File(['{}'], 'probe.geojson', { type: 'application/geo+json' });
+  try {
+    return navigator.canShare({ files: [probe] });
+  } catch {
+    return false;
+  }
+}
+
+/** Share the coverage GeoJSON via the OS share sheet so the user can hand it
+ * straight to the Meshtastic app (or any other app that opens GeoJSON),
+ * falling back to a plain download if the browser can't share files or the
+ * share sheet fails for a reason other than the user cancelling it. */
+export async function shareGeoJSON(site: Site): Promise<void> {
+  const fc = coverageFeatureCollection(site);
+  const file = new File([JSON.stringify(fc)], `${slug(site.params.transmitter.name)}.geojson`, {
+    type: 'application/geo+json',
+  });
+
+  if (navigator.canShare?.({ files: [file] })) {
+    try {
+      await navigator.share({ files: [file], title: `${site.params.transmitter.name} coverage` });
+      return;
+    } catch (err) {
+      if (err instanceof Error && err.name === 'AbortError') return; // user cancelled
+    }
+  }
+  download(file.name, file);
 }
 
 export async function exportPngWorldFile(site: Site): Promise<void> {

--- a/src/store.ts
+++ b/src/store.ts
@@ -10,7 +10,7 @@ import { BasemapControl, ExportControl, MeasureControl } from './map/controls.ts
 import { SearchControl } from './map/search.ts';
 import { coverageImage, cropToRadius } from './map/overlay.ts';
 import { coverageContours } from './map/contours.ts';
-import { exportGeoJSON, exportKml, exportPngWorldFile } from './map/export.ts';
+import { canShareFiles, exportGeoJSON, exportKml, exportPngWorldFile, shareGeoJSON } from './map/export.ts';
 import type { WasmCoverageEngine } from './engine/WasmCoverageEngine.ts';
 import type { CoverageProgress } from './engine/CoverageEngine.ts';
 import { toEngineParams, type CoverageRequest, METERS_PER_FOOT, MAX_RADIUS_METERS } from './engine/params.ts';
@@ -113,6 +113,7 @@ function buildSitePopup(site: Site): HTMLElement {
       <button type="button" data-fmt="geojson">GeoJSON</button>
       <button type="button" data-fmt="png">PNG</button>
       <button type="button" data-fmt="kml">KML</button>
+      ${canShareFiles() ? '<button type="button" data-fmt="share">Send to App</button>' : ''}
     </div>`;
   el.querySelectorAll<HTMLButtonElement>('button[data-fmt]').forEach((b) =>
     b.addEventListener('click', () => {
@@ -120,6 +121,7 @@ function buildSitePopup(site: Site): HTMLElement {
       if (fmt === 'geojson') exportGeoJSON(site);
       else if (fmt === 'png') void exportPngWorldFile(site);
       else if (fmt === 'kml') void exportKml(site);
+      else if (fmt === 'share') void shareGeoJSON(site);
     })
   );
   return el;


### PR DESCRIPTION
## Summary
- Add a "Send to App" button alongside the existing GeoJSON/PNG/KML export buttons on a site's map popup.
- Uses the Web Share API (`navigator.share({ files: [...] })`) to hand the same styled contour GeoJSON to the OS share sheet, where Meshtastic already appears as a destination (it's registered for the `.geojson`/`public.json` document type).
- Falls back to a plain download when the browser can't share files (feature-detected via `canShareFiles()`), so desktop users just don't see the button.
- Companion change in `meshtastic/Meshtastic-Apple` wires up the app side to actually import the file when received this way (PR to follow).

## Test plan
- [x] `vue-tsc -b` passes
- [x] `vitest run` passes (48 passed, 1 skipped)
- [ ] Manual: on iOS Safari, run a coverage simulation, tap the site marker, tap "Send to App" in the export popup, confirm the share sheet appears and "Meshtastic" is offered

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new sharing option to send exported map data through the device’s share sheet when supported.
  * A “Send to App” button now appears for compatible devices, making it easier to share files directly.

* **Bug Fixes**
  * Improved export handling so sharing falls back to a download when direct sharing isn’t available or fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->