### PR TITLE
feat: app hand-off — query prefill, autorun on load, source metadata in export

### DIFF
--- a/src/map/export.ts
+++ b/src/map/export.ts
@@ -79,12 +79,16 @@ function worldFile(result: CoverageResult): string {
 }
 
 function coverageFeatureCollection(site: Site) {
-  return coverageContours(site.result, {
+  const fc = coverageContours(site.result, {
     colorScale: site.params.display.color_scale,
     minDbm: site.params.display.min_dbm,
     maxDbm: site.params.display.max_dbm,
     sensitivityDbm: site.params.receiver.rx_sensitivity,
   });
+  // Foreign top-level members (RFC 7946 §6.1) — renderers ignore them, but an
+  // importing app (e.g. the Meshtastic mobile apps) can name/associate the
+  // overlay from the source site instead of a filename or "Layer N".
+  return { ...fc, properties: { generator: 'meshtastic-site-planner', name: site.params.transmitter.name } };
 }
 
 export function exportGeoJSON(site: Site): void {

--- a/src/permalink.ts
+++ b/src/permalink.ts
@@ -57,3 +57,75 @@ export function clearSharedHash(): void {
   if (typeof location === 'undefined' || !location.hash.includes(HASH_PREFIX)) return;
   history.replaceState(null, '', location.pathname + location.search);
 }
+
+/* --- App hand-off (query string) --------------------------------------------
+ * A minimal, stable query contract so a native app (e.g. the Meshtastic mobile
+ * apps) can deep-link into the planner prefilled and, optionally, auto-run —
+ * without knowing the internal SplatParams shape or base64-encoding JSON:
+ *
+ *   ?lat=51.05&lon=-114.07&name=Tower%20A&tx_power=0.5&tx_freq=915&tx_height=12&tx_gain=5.5&run=1
+ *
+ * Only the keys present are applied (merged over the factory defaults); `run=1`
+ * (also accepted in the hash) computes coverage as soon as the map is ready. */
+
+const QUERY_TX_NUMS = ['tx_power', 'tx_freq', 'tx_height', 'tx_gain'] as const;
+const QUERY_KEYS = ['lat', 'lon', 'name', ...QUERY_TX_NUMS, 'run'];
+
+function finiteNum(s: string | null): number | null {
+  if (s == null || s.trim() === '') return null;
+  const n = Number(s);
+  return Number.isFinite(n) ? n : null;
+}
+
+function isTruthy(v: string | null | undefined): boolean {
+  return v === '1' || v === 'true';
+}
+
+/** Partial params from the flat `?lat=&lon=&name=&tx_*=` query contract, or null
+ * if none are present. Shape matches what mergeParams() merges over defaults. */
+export function decodeSharedQuery(): unknown | null {
+  if (typeof location === 'undefined' || !location.search) return null;
+  const q = new URLSearchParams(location.search);
+  const tx: Record<string, unknown> = {};
+  const lat = finiteNum(q.get('lat'));
+  const lon = finiteNum(q.get('lon'));
+  if (lat != null) tx.tx_lat = lat;
+  if (lon != null) tx.tx_lon = lon;
+  const name = q.get('name');
+  if (name) tx.name = name;
+  for (const k of QUERY_TX_NUMS) {
+    const v = finiteNum(q.get(k));
+    if (v != null) tx[k] = v;
+  }
+  return Object.keys(tx).length ? { transmitter: tx } : null;
+}
+
+/** True if the URL asks the planner to compute coverage immediately on load
+ * (`?run=1` or `#...&run=1`). Ordinary shared permalinks omit it so they don't
+ * kick off a heavy simulation unexpectedly. */
+export function sharedRunRequested(): boolean {
+  if (typeof location === 'undefined') return false;
+  if (isTruthy(new URLSearchParams(location.search).get('run'))) return true;
+  const hash = location.hash.replace(/^#/, '');
+  return hash.split('&').some((p) => {
+    const [k, v] = p.split('=');
+    return k === 'run' && isTruthy(v);
+  });
+}
+
+/** Drop the app hand-off query keys from the address bar (no reload) so a
+ * refresh doesn't re-import or re-run; unrelated query keys are preserved. */
+export function clearSharedQuery(): void {
+  if (typeof location === 'undefined' || !location.search) return;
+  const q = new URLSearchParams(location.search);
+  let changed = false;
+  for (const k of QUERY_KEYS) {
+    if (q.has(k)) {
+      q.delete(k);
+      changed = true;
+    }
+  }
+  if (!changed) return;
+  const search = q.toString();
+  history.replaceState(null, '', location.pathname + (search ? `?${search}` : '') + location.hash);
+}

--- a/src/store.ts
+++ b/src/store.ts
@@ -16,7 +16,14 @@ import type { CoverageProgress } from './engine/CoverageEngine.ts';
 import { toEngineParams, type CoverageRequest, METERS_PER_FOOT, MAX_RADIUS_METERS } from './engine/params.ts';
 import { analyzeLink, type LinkAnalysis } from './engine/link.ts';
 import { loadParams, mergeParams, saveParams } from './persist.ts';
-import { decodeSharedHash, buildShareUrl, clearSharedHash } from './permalink.ts';
+import {
+  decodeSharedHash,
+  decodeSharedQuery,
+  sharedRunRequested,
+  buildShareUrl,
+  clearSharedHash,
+  clearSharedQuery,
+} from './permalink.ts';
 import { coverageStats } from './coverageStats.ts';
 import { TerrainService } from './terrain/TerrainService.ts';
 
@@ -187,8 +194,17 @@ function defaultParams(): SplatParams {
  * (#12), which win over the factory defaults. */
 function initialParams(): SplatParams {
   const d = defaultParams();
-  const shared = decodeSharedHash();
-  return shared ? mergeParams(d, shared) : loadParams(d);
+  const cfg = decodeSharedHash();
+  const query = decodeSharedQuery();
+  // An explicit deep link — a shared #cfg permalink (#9) or the flat ?lat=&lon=…
+  // app hand-off — wins over persisted params (#12); cfg is the base and the
+  // query overrides it, so `#cfg=…` and `?lat=…` can be combined.
+  if (cfg || query) {
+    let p = cfg ? mergeParams(d, cfg) : d;
+    if (query) p = mergeParams(p, query);
+    return p;
+  }
+  return loadParams(d);
 }
 
 const useStore = defineStore('store', {
@@ -213,6 +229,9 @@ const useStore = defineStore('store', {
       highpointMessage: '' as string,
       // Restore from a shared link (#9) or the last-used params (#12).
       splatParams: initialParams(),
+      /** App hand-off: run coverage as soon as the map is ready (#cfg/?run=1).
+       * Captured at store creation, before consumeSharedLink() clears the URL. */
+      autoRun: sharedRunRequested(),
       /** Transient "Copied!" feedback for the share button (#9). */
       shareCopied: false,
       /** Measure/ruler tool (#15). */
@@ -502,9 +521,10 @@ const useStore = defineStore('store', {
     /** If the page opened from a shared link, persist those params and drop the
      * hash so later edits aren't overridden by the link on the next reload. */
     consumeSharedLink() {
-      if (decodeSharedHash()) {
+      if (decodeSharedHash() || decodeSharedQuery()) {
         saveParams(this.splatParams);
         clearSharedHash();
+        clearSharedQuery();
       }
     },
 
@@ -767,6 +787,12 @@ const useStore = defineStore('store', {
         if (!map) return;
         applyBasemap(map, DEFAULT_BASEMAP);
         this.syncOverlays();
+        // App hand-off (#cfg/?run=1): compute coverage once the map is ready, so
+        // the resulting overlay and site marker have somewhere to attach.
+        if (this.autoRun) {
+          this.autoRun = false;
+          void this.runSimulation();
+        }
       });
 
       // Tap a contour band to read its signal level (vector-only). Querying

--- a/test/permalink.test.ts
+++ b/test/permalink.test.ts
@@ -1,7 +1,17 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, afterEach, vi } from 'vitest';
 
-import { encodeParams, decodeParams } from '../src/permalink';
+import {
+  encodeParams,
+  decodeParams,
+  decodeSharedQuery,
+  sharedRunRequested,
+} from '../src/permalink';
 import type { SplatParams } from '../src/types';
+
+/** Stub the global `location` (absent in the node test env) with a given URL. */
+function stubLocation(search: string, hash = ''): void {
+  vi.stubGlobal('location', { search, hash, pathname: '/', origin: 'https://x' });
+}
 
 function sample(): SplatParams {
   return {
@@ -34,5 +44,36 @@ describe('permalink codec', () => {
   it('returns null for malformed encodings', () => {
     expect(decodeParams('not-valid-base64!!')).toBeNull();
     expect(decodeParams('')).toBeNull();
+  });
+});
+
+describe('app hand-off query contract', () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  it('parses lat/lon/name and numeric tx_* into a partial transmitter', () => {
+    stubLocation('?lat=51.05&lon=-114.07&name=Tower%20A&tx_power=0.5&tx_freq=915&tx_height=12&tx_gain=5.5');
+    expect(decodeSharedQuery()).toEqual({
+      transmitter: { tx_lat: 51.05, tx_lon: -114.07, name: 'Tower A', tx_power: 0.5, tx_freq: 915, tx_height: 12, tx_gain: 5.5 },
+    });
+  });
+
+  it('omits missing and non-numeric fields, and returns null when nothing usable', () => {
+    stubLocation('?lat=51.05&tx_power=abc');
+    expect(decodeSharedQuery()).toEqual({ transmitter: { tx_lat: 51.05 } });
+    stubLocation('?run=1'); // run alone is not params
+    expect(decodeSharedQuery()).toBeNull();
+    stubLocation('');
+    expect(decodeSharedQuery()).toBeNull();
+  });
+
+  it('detects the run flag in the query or the hash, but not otherwise', () => {
+    stubLocation('?run=1');
+    expect(sharedRunRequested()).toBe(true);
+    stubLocation('?lat=1', '#cfg=abc&run=true');
+    expect(sharedRunRequested()).toBe(true);
+    stubLocation('?lat=1', '#cfg=abc');
+    expect(sharedRunRequested()).toBe(false);
+    stubLocation('?run=0');
+    expect(sharedRunRequested()).toBe(false);
   });
 });


### PR DESCRIPTION
## What

Three small changes that smooth the round-trip with the Meshtastic mobile apps. Those apps can already *receive* a coverage GeoJSON via the "Send to App" share sheet (#72); this lets an app deep-link *into* the planner prefilled and get a styled layer back with minimal friction.

- **Flat query contract** so an app can prefill without knowing the internal `SplatParams` shape or base64-encoding JSON:
  ```
  ?lat=51.05&lon=-114.07&name=Tower%20A&tx_power=0.5&tx_freq=915&tx_height=12&tx_gain=5.5&run=1
  ```
  Present keys are parsed into a partial transmitter and merged over the factory defaults. Combinable with a `#cfg=` permalink (cfg is the base, the query overrides). The map already centers on the transmitter, so this positions the view and draft pin for free.
- **Autorun**: `?run=1` (also accepted in the hash) computes coverage as soon as the map is ready, removing the manual **Run** tap on hand-off. The flag is captured at store creation (before `consumeSharedLink()` clears the URL) and gated, so ordinary shared permalinks never kick off a heavy simulation unexpectedly. The hand-off query keys are stripped afterward so a refresh doesn't re-run.
- **Source metadata**: the exported GeoJSON `FeatureCollection` carries a top-level `properties: { generator, name }` — a foreign member (RFC 7946 §6.1) that renderers ignore, but an importing app can use to name/associate the overlay from its source site instead of a filename or "Layer N".

## Why

Pairs with the "Send to App" share (#72) to close the loop end-to-end: **app → planner (prefilled) → Run → Send to App → overlay**. The query contract keeps the app decoupled from the planner's internal params; autorun removes the one manual step in the hand-off; the export metadata lets the returned layer be self-describing. Companion app work: Android import via share/open-in (mirrors #72) and the existing simplestyle rendering (meshtastic/Meshtastic-Android#6088); iOS import (meshtastic/Meshtastic-Apple#2056) + styling (meshtastic/Meshtastic-Apple#2037).

## Notes

- Only `permalink.ts`, `store.ts`, and `map/export.ts` change (plus tests). No new deps.
- Partial `#cfg=` already worked (`mergeParams` deep-merges per section); the query contract is purely a simpler, drift-proof surface for apps.
- Autorun with no position falls back to the default location — apps should always send `lat`/`lon` alongside `run=1`.

## Test plan

- [x] `vue-tsc -b` clean
- [x] `vitest run` — 51 passed / 1 skipped (added unit tests for the query + run-flag parsers: partial parse, invalid/missing fields, run in query vs hash)
- [ ] Manual: open `…/?lat=…&lon=…&name=…&run=1`, confirm the map centers, the sim auto-runs, and **Send to App** offers a GeoJSON whose `properties.name` matches

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Shareable links can now include map settings in the URL query string, making it easier to hand off a specific setup.
  * Links can optionally trigger an automatic coverage run when opened.

* **Bug Fixes**
  * Shared links now preserve unrelated URL parameters while clearing only app-specific link data.
  * Exported map data now includes helpful top-level metadata such as the site name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->