### PR TITLE
feat: native coverage bridge + full flat query contract for the app hand-off

### DIFF
--- a/src/map/export.ts
+++ b/src/map/export.ts
@@ -96,6 +96,18 @@ export function exportGeoJSON(site: Site): void {
   download(`${slug(site.params.transmitter.name)}.geojson`, new Blob([JSON.stringify(fc)], { type: 'application/geo+json' }));
 }
 
+/** Hand the styled coverage GeoJSON to a native host if one injected a bridge
+ * (e.g. an Android WebView that loaded the planner headless with `&run=1` and a
+ * `window.__meshtasticNative` JS interface). No-op in a normal browser — that
+ * path uses the share sheet / download instead. */
+export function postCoverageToBridge(site: Site): void {
+  const bridge = (globalThis as { __meshtasticNative?: { onCoverage?: (geojson: string) => void } })
+    .__meshtasticNative;
+  if (typeof bridge?.onCoverage === 'function') {
+    bridge.onCoverage(JSON.stringify(coverageFeatureCollection(site)));
+  }
+}
+
 /** True if the browser can hand a file to the OS share sheet (e.g. iOS/Android
  * "Open in Meshtastic"). Desktop and older mobile browsers report false —
  * callers should fall back to a plain download. */

--- a/src/map/export.ts
+++ b/src/map/export.ts
@@ -104,7 +104,12 @@ export function postCoverageToBridge(site: Site): void {
   const bridge = (globalThis as { __meshtasticNative?: { onCoverage?: (geojson: string) => void } })
     .__meshtasticNative;
   if (typeof bridge?.onCoverage === 'function') {
-    bridge.onCoverage(JSON.stringify(coverageFeatureCollection(site)));
+    // Best-effort side channel: a throwing host must not fail an already-successful simulation.
+    try {
+      bridge.onCoverage(JSON.stringify(coverageFeatureCollection(site)));
+    } catch (error) {
+      console.error('postCoverageToBridge: native bridge threw', error);
+    }
   }
 }
 

--- a/src/permalink.ts
+++ b/src/permalink.ts
@@ -63,13 +63,13 @@ export function clearSharedHash(): void {
  * apps) can deep-link into the planner prefilled and, optionally, auto-run —
  * without knowing the internal SplatParams shape or base64-encoding JSON:
  *
- *   ?lat=51.05&lon=-114.07&name=Tower%20A&tx_power=0.5&tx_freq=915&tx_height=12&tx_gain=5.5&run=1
+ *   ?lat=51.05&lon=-114.07&name=Tower%20A&tx_power=0.5&tx_freq=915&tx_height=12&tx_gain=5.5&color_scale=plasma&run=1
  *
  * Only the keys present are applied (merged over the factory defaults); `run=1`
  * (also accepted in the hash) computes coverage as soon as the map is ready. */
 
 const QUERY_TX_NUMS = ['tx_power', 'tx_freq', 'tx_height', 'tx_gain'] as const;
-const QUERY_KEYS = ['lat', 'lon', 'name', ...QUERY_TX_NUMS, 'run'];
+const QUERY_KEYS = ['lat', 'lon', 'name', ...QUERY_TX_NUMS, 'color_scale', 'run'];
 
 function finiteNum(s: string | null): number | null {
   if (s == null || s.trim() === '') return null;
@@ -97,7 +97,13 @@ export function decodeSharedQuery(): unknown | null {
     const v = finiteNum(q.get(k));
     if (v != null) tx[k] = v;
   }
-  return Object.keys(tx).length ? { transmitter: tx } : null;
+  const display: Record<string, unknown> = {};
+  const colorScale = q.get('color_scale');
+  if (colorScale) display.color_scale = colorScale;
+  const params: Record<string, unknown> = {};
+  if (Object.keys(tx).length) params.transmitter = tx;
+  if (Object.keys(display).length) params.display = display;
+  return Object.keys(params).length ? params : null;
 }
 
 /** True if the URL asks the planner to compute coverage immediately on load

--- a/src/permalink.ts
+++ b/src/permalink.ts
@@ -5,6 +5,7 @@
  * the small read/build/clear functions) so the codec is unit-testable. */
 
 import type { SplatParams } from './types';
+import { COLORMAP_NAMES } from './render/colormaps';
 
 const HASH_PREFIX = 'cfg=';
 
@@ -83,7 +84,7 @@ function isTruthy(v: string | null | undefined): boolean {
 
 /** Partial params from the flat `?lat=&lon=&name=&tx_*=` query contract, or null
  * if none are present. Shape matches what mergeParams() merges over defaults. */
-export function decodeSharedQuery(): unknown | null {
+export function decodeSharedQuery(): Record<string, unknown> | null {
   if (typeof location === 'undefined' || !location.search) return null;
   const q = new URLSearchParams(location.search);
   const tx: Record<string, unknown> = {};
@@ -99,7 +100,8 @@ export function decodeSharedQuery(): unknown | null {
   }
   const display: Record<string, unknown> = {};
   const colorScale = q.get('color_scale');
-  if (colorScale) display.color_scale = colorScale;
+  // Only pass through a known colormap — an unknown value would break the legend/colorbar asset filename.
+  if (colorScale && COLORMAP_NAMES.includes(colorScale)) display.color_scale = colorScale;
   const params: Record<string, unknown> = {};
   if (Object.keys(tx).length) params.transmitter = tx;
   if (Object.keys(display).length) params.display = display;

--- a/src/permalink.ts
+++ b/src/permalink.ts
@@ -149,12 +149,13 @@ export function decodeSharedQuery(): Record<string, unknown> | null {
 
   // Enums: only known values pass through (an unknown climate/polarization throws
   // in the engine, an unknown colormap breaks a legend asset); else the default.
+  // Own-property checks so inherited keys (`toString`, `constructor`, …) can't slip past the whitelist.
   const climate = q.get('radio_climate');
-  if (climate && climate in CLIMATE_CODES) {
+  if (climate && Object.prototype.hasOwnProperty.call(CLIMATE_CODES, climate)) {
     sections.environment.radio_climate = climate;
   }
   const polarization = q.get('polarization');
-  if (polarization && polarization in POLARIZATION_CODES) {
+  if (polarization && Object.prototype.hasOwnProperty.call(POLARIZATION_CODES, polarization)) {
     sections.environment.polarization = polarization;
   }
   const colorScale = q.get('color_scale');

--- a/src/permalink.ts
+++ b/src/permalink.ts
@@ -6,6 +6,7 @@
 
 import type { SplatParams } from './types';
 import { COLORMAP_NAMES } from './render/colormaps';
+import { CLIMATE_CODES, POLARIZATION_CODES } from './engine/params';
 
 const HASH_PREFIX = 'cfg=';
 
@@ -60,17 +61,57 @@ export function clearSharedHash(): void {
 }
 
 /* --- App hand-off (query string) --------------------------------------------
- * A minimal, stable query contract so a native app (e.g. the Meshtastic mobile
+ * A stable, readable query contract so a native app (e.g. the Meshtastic mobile
  * apps) can deep-link into the planner prefilled and, optionally, auto-run —
- * without knowing the internal SplatParams shape or base64-encoding JSON:
+ * without base64-encoding JSON or knowing the internal SplatParams nesting:
  *
- *   ?lat=51.05&lon=-114.07&name=Tower%20A&tx_power=0.5&tx_freq=915&tx_height=12&tx_gain=5.5&color_scale=plasma&run=1
+ *   ?lat=51.05&lon=-114.07&name=Tower%20A&tx_power=0.5&tx_freq=915&tx_height=12
+ *     &tx_gain=5.5&rx_sensitivity=-130&max_range=50&high_res=1&color_scale=plasma&run=1
  *
- * Only the keys present are applied (merged over the factory defaults); `run=1`
- * (also accepted in the hash) computes coverage as soon as the map is ready. */
+ * Keys map onto SplatParams sections via QUERY_NUM_FIELDS plus the name/bool/enum
+ * handling below; only the keys present are applied (merged over the factory
+ * defaults, per-section). `run=1` (also accepted in the hash) computes coverage
+ * as soon as the map is ready. Unknown enum values are ignored — the default
+ * applies — so a bad string can't throw in the engine or break a legend asset. */
 
-const QUERY_TX_NUMS = ['tx_power', 'tx_freq', 'tx_height', 'tx_gain'] as const;
-const QUERY_KEYS = ['lat', 'lon', 'name', ...QUERY_TX_NUMS, 'color_scale', 'run'];
+type Section = keyof SplatParams;
+
+// Numeric flat keys → [section, field]. Grouped by section so a partial merges
+// cleanly over the defaults (mergeParams merges section-by-section).
+// (rx_gain is intentionally omitted: it's ignored for area coverage, only used
+// in point-to-point link analysis, so a hand-off can't meaningfully set it.)
+const QUERY_NUM_FIELDS: Record<string, [Section, string]> = {
+  lat: ['transmitter', 'tx_lat'],
+  lon: ['transmitter', 'tx_lon'],
+  tx_power: ['transmitter', 'tx_power'],
+  tx_freq: ['transmitter', 'tx_freq'],
+  tx_height: ['transmitter', 'tx_height'],
+  tx_gain: ['transmitter', 'tx_gain'],
+  rx_sensitivity: ['receiver', 'rx_sensitivity'],
+  rx_height: ['receiver', 'rx_height'],
+  rx_loss: ['receiver', 'rx_loss'],
+  max_range: ['simulation', 'simulation_extent'],
+  situation_fraction: ['simulation', 'situation_fraction'],
+  time_fraction: ['simulation', 'time_fraction'],
+  clutter_height: ['environment', 'clutter_height'],
+  ground_dielectric: ['environment', 'ground_dielectric'],
+  ground_conductivity: ['environment', 'ground_conductivity'],
+  atmosphere_bending: ['environment', 'atmosphere_bending'],
+  min_dbm: ['display', 'min_dbm'],
+  max_dbm: ['display', 'max_dbm'],
+  overlay_transparency: ['display', 'overlay_transparency'],
+};
+
+// Every hand-off key, for clearSharedQuery() (numeric + name/bool/enum + run).
+const QUERY_KEYS = [
+  ...Object.keys(QUERY_NUM_FIELDS),
+  'name',
+  'high_res',
+  'radio_climate',
+  'polarization',
+  'color_scale',
+  'run',
+];
 
 function finiteNum(s: string | null): number | null {
   if (s == null || s.trim() === '') return null;
@@ -82,29 +123,49 @@ function isTruthy(v: string | null | undefined): boolean {
   return v === '1' || v === 'true';
 }
 
-/** Partial params from the flat `?lat=&lon=&name=&tx_*=` query contract, or null
- * if none are present. Shape matches what mergeParams() merges over defaults. */
+/** Partial params from the flat query hand-off contract, or null if none are
+ * present. Shape matches what mergeParams() merges over defaults (per section). */
 export function decodeSharedQuery(): Record<string, unknown> | null {
   if (typeof location === 'undefined' || !location.search) return null;
   const q = new URLSearchParams(location.search);
-  const tx: Record<string, unknown> = {};
-  const lat = finiteNum(q.get('lat'));
-  const lon = finiteNum(q.get('lon'));
-  if (lat != null) tx.tx_lat = lat;
-  if (lon != null) tx.tx_lon = lon;
-  const name = q.get('name');
-  if (name) tx.name = name;
-  for (const k of QUERY_TX_NUMS) {
-    const v = finiteNum(q.get(k));
-    if (v != null) tx[k] = v;
+  const sections: Record<Section, Record<string, unknown>> = {
+    transmitter: {},
+    receiver: {},
+    environment: {},
+    simulation: {},
+    display: {},
+  };
+
+  for (const [key, [section, field]] of Object.entries(QUERY_NUM_FIELDS)) {
+    const v = finiteNum(q.get(key));
+    if (v != null) sections[section][field] = v;
   }
-  const display: Record<string, unknown> = {};
+
+  const name = q.get('name');
+  if (name) sections.transmitter.name = name;
+
+  const highRes = q.get('high_res');
+  if (highRes != null) sections.simulation.high_resolution = isTruthy(highRes);
+
+  // Enums: only known values pass through (an unknown climate/polarization throws
+  // in the engine, an unknown colormap breaks a legend asset); else the default.
+  const climate = q.get('radio_climate');
+  if (climate && climate in CLIMATE_CODES) {
+    sections.environment.radio_climate = climate;
+  }
+  const polarization = q.get('polarization');
+  if (polarization && polarization in POLARIZATION_CODES) {
+    sections.environment.polarization = polarization;
+  }
   const colorScale = q.get('color_scale');
-  // Only pass through a known colormap — an unknown value would break the legend/colorbar asset filename.
-  if (colorScale && COLORMAP_NAMES.includes(colorScale)) display.color_scale = colorScale;
+  if (colorScale && COLORMAP_NAMES.includes(colorScale)) {
+    sections.display.color_scale = colorScale;
+  }
+
   const params: Record<string, unknown> = {};
-  if (Object.keys(tx).length) params.transmitter = tx;
-  if (Object.keys(display).length) params.display = display;
+  for (const [section, obj] of Object.entries(sections)) {
+    if (Object.keys(obj).length) params[section] = obj;
+  }
   return Object.keys(params).length ? params : null;
 }
 

--- a/src/store.ts
+++ b/src/store.ts
@@ -10,7 +10,7 @@ import { BasemapControl, ExportControl, MeasureControl } from './map/controls.ts
 import { SearchControl } from './map/search.ts';
 import { coverageImage, cropToRadius } from './map/overlay.ts';
 import { coverageContours } from './map/contours.ts';
-import { canShareFiles, exportGeoJSON, exportKml, exportPngWorldFile, shareGeoJSON } from './map/export.ts';
+import { canShareFiles, exportGeoJSON, exportKml, exportPngWorldFile, postCoverageToBridge, shareGeoJSON } from './map/export.ts';
 import type { WasmCoverageEngine } from './engine/WasmCoverageEngine.ts';
 import type { CoverageProgress } from './engine/CoverageEngine.ts';
 import { toEngineParams, type CoverageRequest, METERS_PER_FOOT, MAX_RADIUS_METERS } from './engine/params.ts';
@@ -913,9 +913,13 @@ const useStore = defineStore('store', {
           siteMarkers.set(id, marker);
         }
 
-        this.splatParams.transmitter.name = randanimalSync();
         this.syncOverlays();
         this.simulationState = 'completed';
+        // Headless/native hand-off (Android WebView): push the styled GeoJSON to
+        // the injected bridge, before the name is randomized below, so it carries
+        // the source site's name. No-op in a normal browser.
+        postCoverageToBridge(site);
+        this.splatParams.transmitter.name = randanimalSync();
       } catch (error) {
         if (error instanceof DOMException && error.name === 'AbortError') {
           console.log('Simulation cancelled');

--- a/test/permalink.test.ts
+++ b/test/permalink.test.ts
@@ -57,6 +57,13 @@ describe('app hand-off query contract', () => {
     });
   });
 
+  it('passes a known color_scale into display but drops an unknown one', () => {
+    stubLocation('?lat=51.05&color_scale=turbo');
+    expect(decodeSharedQuery()).toEqual({ transmitter: { tx_lat: 51.05 }, display: { color_scale: 'turbo' } });
+    stubLocation('?lat=51.05&color_scale=bogus');
+    expect(decodeSharedQuery()).toEqual({ transmitter: { tx_lat: 51.05 } });
+  });
+
   it('omits missing and non-numeric fields, and returns null when nothing usable', () => {
     stubLocation('?lat=51.05&tx_power=abc');
     expect(decodeSharedQuery()).toEqual({ transmitter: { tx_lat: 51.05 } });

--- a/test/permalink.test.ts
+++ b/test/permalink.test.ts
@@ -64,6 +64,29 @@ describe('app hand-off query contract', () => {
     expect(decodeSharedQuery()).toEqual({ transmitter: { tx_lat: 51.05 } });
   });
 
+  it('maps advanced keys onto their sections (receiver / simulation / environment / display)', () => {
+    stubLocation(
+      '?rx_sensitivity=-135&rx_height=3&rx_loss=1&max_range=50&high_res=1' +
+        '&situation_fraction=90&clutter_height=2&min_dbm=-140&max_dbm=-70&overlay_transparency=25',
+    );
+    expect(decodeSharedQuery()).toEqual({
+      receiver: { rx_sensitivity: -135, rx_height: 3, rx_loss: 1 },
+      simulation: { simulation_extent: 50, high_resolution: true, situation_fraction: 90 },
+      environment: { clutter_height: 2 },
+      display: { min_dbm: -140, max_dbm: -70, overlay_transparency: 25 },
+    });
+  });
+
+  it('passes known climate/polarization enums but drops unknown ones; high_res=0 is false', () => {
+    stubLocation('?radio_climate=desert&polarization=horizontal&high_res=0');
+    expect(decodeSharedQuery()).toEqual({
+      environment: { radio_climate: 'desert', polarization: 'horizontal' },
+      simulation: { high_resolution: false },
+    });
+    stubLocation('?radio_climate=bogus&polarization=sideways');
+    expect(decodeSharedQuery()).toBeNull();
+  });
+
   it('omits missing and non-numeric fields, and returns null when nothing usable', () => {
     stubLocation('?lat=51.05&tx_power=abc');
     expect(decodeSharedQuery()).toEqual({ transmitter: { tx_lat: 51.05 } });

--- a/test/permalink.test.ts
+++ b/test/permalink.test.ts
@@ -85,6 +85,9 @@ describe('app hand-off query contract', () => {
     });
     stubLocation('?radio_climate=bogus&polarization=sideways');
     expect(decodeSharedQuery()).toBeNull();
+    // Inherited Object keys must not slip past the whitelist (own-property check).
+    stubLocation('?radio_climate=toString&polarization=constructor');
+    expect(decodeSharedQuery()).toBeNull();
   });
 
   it('omits missing and non-numeric fields, and returns null when nothing usable', () => {


### PR DESCRIPTION
## What

Follow-ups to the app hand-off (#73), used by the Meshtastic mobile apps that deep-link into the planner.

- **Native host bridge** (`postCoverageToBridge`): when the planner runs inside a native host — e.g. an Android WebView that loads it headless with `&run=1` and injects a `window.__meshtasticNative` JS interface — post the styled coverage `FeatureCollection` straight to that bridge on simulation success (before the transmitter name is randomized, so the payload keeps the source site's name). No-op in a normal browser, which keeps using the share sheet / download. Wrapped in try/catch so a throwing host can't flip an already-successful run to `failed`.
- **Full flat query contract**: the `?lat=&lon=&…` hand-off now covers every applicable `SplatParams` section as readable keys — not just the transmitter. Added: `rx_sensitivity`, `rx_height`, `rx_loss` (receiver); `max_range`, `high_res`, `situation_fraction`, `time_fraction` (simulation); `clutter_height`, `ground_dielectric`, `ground_conductivity`, `atmosphere_bending`, `radio_climate`, `polarization` (environment); `min_dbm`, `max_dbm`, `overlay_transparency`, `color_scale` (display). Each maps onto its section (`QUERY_NUM_FIELDS`) and merges per-section over defaults. Unknown `radio_climate`/`polarization`/`color_scale` values are ignored (default applies) so a bad string can't throw in the engine or break a legend asset. `rx_gain` is omitted (ignored for area coverage). This lets an app expose the planner's advanced params without base64-encoding a `#cfg` blob.

## Why

Together these let a native app drive the planner end-to-end without the share sheet: hand off params (incl. palette) → autorun → receive the styled GeoJSON via the bridge. Consumed by the Meshtastic-Android Site Planner estimate flow (companion PR).

## Notes

- `src/map/export.ts`, `src/store.ts`, `src/permalink.ts` only. No new deps.
- Both are presence/opt-in gated — a normal browser session is unchanged.

## Test plan

- [x] `vue-tsc -b` clean
- [x] `vitest run` — 51 passed / 1 skipped (query + run-flag parser tests updated for `color_scale`)
- [x] Verified end-to-end from Meshtastic-Android: headless WebView loads `…?…&run=1&bridge=1`, planner autoruns, bridge delivers the styled GeoJSON (palette honored — confirmed Turbo vs Plasma hex output)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Shared links now support additional map hand-off parameters, including `high_res`, `radio_climate`, `polarization`, and `color_scale` (when valid).
  * Added native/headless export support to hand off coverage GeoJSON to compatible integrations.
* **Bug Fixes**
  * Improved simulation completion by syncing overlays before marking the run as completed.
  * Ensured bridged/exported coverage uses the intended site label before any display name randomization.
* **Tests**
  * Expanded permalink decoding tests for nested parameter mapping, `color_scale` validation, enum handling, and rejecting unexpected/prototype values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
