### PR TITLE
feat(bridge): find a relay point when a point-to-point link is too weak

### DIFF
--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -1,0 +1,192 @@
+/* Bridge-node placement analysis.
+ *
+ * Given ONE simulated site (A) and a second point (B) — placed on the map via
+ * the point-to-point link tool and given the site's own radio values — find the
+ * regions where a single *additional* node could act as a relay and bridge them:
+ * i.e. where a node can be reached by BOTH transmitters.
+ *
+ * The store already holds A's received-power dBm grid. B's grid is computed on
+ * demand with the same engine (same site + receiver values, moved to B), so the
+ * two coverage fields are directly comparable. Because links are modeled as
+ * symmetric (the same ITM path is used for the reverse direction — see
+ * engine/link.ts), a cell where `A.dbm >= thresholdA` means a relay there can
+ * *hear A*, and a cell where `B.dbm >= thresholdB` means it can *hear B*. A cell
+ * satisfying both is therefore exactly a place a single node can bridge the two
+ * otherwise-disconnected networks.
+ *
+ *  - The bridgeable region is the coverage OVERLAP of A and B.
+ *  - The "best" placement is the cell in that region maximizing min(A,B) dBm —
+ *    the node stays as deep inside both coverage edges as possible.
+ *
+ * This module is intentionally pure (CoverageResult in → overlap grid + stats
+ * out) and free of any MapLibre/DOM dependency, so the same code can back a
+ * future server/edge API, mirrors coverageStats.ts and coverageContours.ts, and
+ * is trivially unit-testable. Rendering the returned grid reuses the existing
+ * heatmap (src/map/overlay.ts) and contour (src/map/contours.ts) pipelines.
+ */
+
+import type { CoverageResult } from './engine/CoverageEngine';
+
+export interface BridgeInput {
+  /** dBm grid for site A (already radius-cropped). */
+  resultA: CoverageResult;
+  /** dBm grid for site B (already radius-cropped). */
+  resultB: CoverageResult;
+  /** Receiver sensitivity of A's network, dBm. Cells below this can't hear A. */
+  thresholdA: number;
+  /** Receiver sensitivity of B's network, dBm. Cells below this can't hear B. */
+  thresholdB: number;
+  /** Transmitter position of site A (used for direct A<->B link detection). */
+  txLatA: number;
+  txLonA: number;
+  /** Transmitter position of site B. */
+  txLatB: number;
+  txLonB: number;
+}
+
+export interface BridgeCell {
+  lat: number;
+  lon: number;
+  /** min(A.dbm, B.dbm) at this cell, dBm (the overlap score). */
+  score: number;
+}
+
+export interface BridgeResult {
+  /** Overlap field shaped like a CoverageResult so it drops straight into the
+   * existing heatmap/contour renderers. Score = min(A,B) where both A and B
+   * reach their thresholds, else NaN (transparent / outside all bands). */
+  overlap: CoverageResult;
+  /** Best single placement: cell maximizing min(A,B). null if no overlap. */
+  best: BridgeCell | null;
+  /** Signal margin at the best point = best.score - max(thresholdA, thresholdB),
+   * dB (>0 means the bridge is comfortably inside both coverage edges). */
+  bestMarginDb: number | null;
+  /** Ground area of the bridgeable region, km². */
+  areaKm2: number;
+  /** True when at least one cell bridges A and B. */
+  hasOverlap: boolean;
+  /** True when A and B already reach each other directly (a node at B hears A
+   * and a node at A hears B), so no additional relay is needed at all. */
+  directLink: boolean;
+  /** Signal margin (dB) of the direct A<->B link = min(signal-of-A-at-B minus
+   * A's threshold, signal-of-B-at-A minus B's threshold). >0 = comfortable. */
+  directMarginDb: number | null;
+}
+
+const M_PER_DEG_LAT = 111320;
+
+/** True if two rasters share grid geometry (same dims, bounds, resolution) so
+ * they can be combined cell-for-cell with no resampling. */
+function aligned(a: CoverageResult, b: CoverageResult): boolean {
+  return (
+    a.width === b.width &&
+    a.height === b.height &&
+    Math.abs(a.bounds.north - b.bounds.north) < 1e-9 &&
+    Math.abs(a.bounds.south - b.bounds.south) < 1e-9 &&
+    Math.abs(a.bounds.east - b.bounds.east) < 1e-9 &&
+    Math.abs(a.bounds.west - b.bounds.west) < 1e-9 &&
+    Math.abs(a.pixelDegrees - b.pixelDegrees) < 1e-12
+  );
+}
+
+/**
+ * Sample B's dBm at an arbitrary (lat, lon) using nearest-neighbor, wrapping
+ * longitude safely. Returns NaN when the point is outside B's grid.
+ * Only used when A and B are NOT aligned (the common case is aligned).
+ */
+function sampleNearest(result: CoverageResult, lat: number, lon: number): number {
+  const { bounds, width, height, pixelDegrees } = result;
+  if (lat > bounds.north || lat < bounds.south) return NaN;
+  const span = bounds.east - bounds.west;
+  let frac = (lon - bounds.west) / span;
+  frac = ((frac % 1) + 1) % 1; // wrap into [0,1) (handles antimeridian-crossing rasters)
+  const col = Math.min(width - 1, Math.round(frac * (width - 1)));
+  const row = Math.max(0, Math.min(height - 1, Math.round((bounds.north - lat) / pixelDegrees - 0.5)));
+  return result.dbm[row * width + col];
+}
+
+/**
+ * Compute the bridgeable region between two sites and the best relay placement.
+ * Pure and DOM-free; throws only if given zero-dimension rasters.
+ */
+export function computeBridge(input: BridgeInput): BridgeResult {
+  const A = input.resultA;
+  const B = input.resultB;
+  const ta = input.thresholdA;
+  const tb = input.thresholdB;
+  if (A.width <= 0 || A.height <= 0 || B.width <= 0 || B.height <= 0) {
+    throw new Error('coverage rasters must be non-empty');
+  }
+
+  const same = aligned(A, B);
+  const dbm = new Float32Array(A.width * A.height);
+  let bestScore = -Infinity;
+  let bestRow = -1;
+  let bestCol = -1;
+  let overlapCells = 0;
+  let areaM2 = 0;
+
+  for (let row = 0; row < A.height; row++) {
+    const lat = A.bounds.north - (row + 0.5) * A.pixelDegrees;
+    const cellAreaM2 =
+      A.pixelDegrees * M_PER_DEG_LAT * A.pixelDegrees * M_PER_DEG_LAT *
+      Math.max(0, Math.cos((lat * Math.PI) / 180));
+    for (let col = 0; col < A.width; col++) {
+      const i = row * A.width + col;
+      const a = A.dbm[i];
+      const b = same
+        ? B.dbm?.[i] ?? NaN
+        : sampleNearest(B, lat, A.bounds.west + (col + 0.5) * A.pixelDegrees);
+      if (a >= ta && b >= tb) {
+        const score = a < b ? a : b; // min(A,B): upstream constraint is the weak link
+        dbm[i] = score;
+        overlapCells++;
+        areaM2 += cellAreaM2;
+        if (score > bestScore) {
+          bestScore = score;
+          bestRow = row;
+          bestCol = col;
+        }
+      } else {
+        dbm[i] = NaN;
+      }
+    }
+  }
+
+  let best: BridgeCell | null = null;
+  let bestMarginDb: number | null = null;
+  if (bestRow >= 0) {
+    const lat = A.bounds.north - (bestRow + 0.5) * A.pixelDegrees;
+    const lon = A.bounds.west + (bestCol + 0.5) * A.pixelDegrees;
+    best = { lat, lon, score: bestScore };
+    bestMarginDb = bestScore - Math.max(ta, tb);
+  }
+
+  const overlap: CoverageResult = {
+    dbm,
+    width: A.width,
+    height: A.height,
+    bounds: A.bounds,
+    pixelDegrees: A.pixelDegrees,
+    // Copied for shape only; the overlap is derived, not a fresh engine run.
+    stats: { ...A.stats },
+  };
+
+  // Direct-link check: if each transmitter is inside the OTHER's coverage, the
+  // two sites already hear each other and no relay is needed.
+  const aAtB = sampleNearest(A, input.txLatB, input.txLonB); // A's signal where B is
+  const bAtA = sampleNearest(B, input.txLatA, input.txLonA); // B's signal where A is
+  const bothKnown = !Number.isNaN(aAtB) && !Number.isNaN(bAtA);
+  const directLink = bothKnown && aAtB >= ta && bAtA >= tb;
+  const directMarginDb = bothKnown ? Math.min(aAtB - ta, bAtA - tb) : null;
+
+  return {
+    overlap,
+    best,
+    bestMarginDb,
+    areaKm2: areaM2 / 1e6,
+    hasOverlap: overlapCells > 0,
+    directLink,
+    directMarginDb,
+  };
+}

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -58,8 +58,9 @@ export interface BridgeResult {
   overlap: CoverageResult;
   /** Best single placement: cell maximizing min(A,B). null if no overlap. */
   best: BridgeCell | null;
-  /** Signal margin at the best point = best.score - max(thresholdA, thresholdB),
-   * dB (>0 means the bridge is comfortably inside both coverage edges). */
+  /** Signal margin at the best point = the weaker of the two per-link margins
+   * (min(A.dbm - thresholdA, B.dbm - thresholdB)), dB (>0 means the bridge is
+   * comfortably inside both coverage edges). */
   bestMarginDb: number | null;
   /** Ground area of the bridgeable region, km². */
   areaKm2: number;
@@ -90,17 +91,30 @@ function aligned(a: CoverageResult, b: CoverageResult): boolean {
 }
 
 /**
- * Sample B's dBm at an arbitrary (lat, lon) using nearest-neighbor, wrapping
- * longitude safely. Returns NaN when the point is outside B's grid.
- * Only used when A and B are NOT aligned (the common case is aligned).
+ * Sample B's dBm at an arbitrary (lat, lon) using nearest-neighbor. Antimeridian
+ * (period-360) crossing is applied ONLY when B's raster actually crosses the
+ * ±180° meridian (region bounds reported beyond ±180, e.g. west=175, east=182.5);
+ * otherwise a longitude outside [west, east] is genuinely outside B's grid and
+ * returns NaN instead of silently wrapping onto an unrelated column. Only used
+ * when A and B are NOT aligned (the common case is aligned).
  */
 function sampleNearest(result: CoverageResult, lat: number, lon: number): number {
   const { bounds, width, height, pixelDegrees } = result;
   if (lat > bounds.north || lat < bounds.south) return NaN;
   const span = bounds.east - bounds.west;
+  if (!(span > 0)) return NaN;
+  // Rasters whose reported bounds lie either side of ±180° cross the
+  // antimeridian (SPLAT reports signed degrees, so the region spans e.g.
+  // 175…182.5 near lon 180); only those wrap by 360°.
+  const crossesAntimeridian = bounds.west < -180 || bounds.east > 180;
   let frac = (lon - bounds.west) / span;
-  frac = ((frac % 1) + 1) % 1; // wrap into [0,1) (handles antimeridian-crossing rasters)
-  const col = Math.min(width - 1, Math.round(frac * (width - 1)));
+  if (crossesAntimeridian) {
+    frac = ((frac % 1) + 1) % 1; // wrap into [0,1)
+  } else if (frac < 0 || frac > 1) {
+    return NaN; // outside [west, east] — genuinely not on this raster
+  }
+  // Nearest pixel center, clamped to the valid column range.
+  const col = Math.min(width - 1, Math.max(0, Math.round(frac * width - 0.5)));
   const row = Math.max(0, Math.min(height - 1, Math.round((bounds.north - lat) / pixelDegrees - 0.5)));
   return result.dbm[row * width + col];
 }
@@ -159,7 +173,14 @@ export function computeBridge(input: BridgeInput): BridgeResult {
     const lat = A.bounds.north - (bestRow + 0.5) * A.pixelDegrees;
     const lon = A.bounds.west + (bestCol + 0.5) * A.pixelDegrees;
     best = { lat, lon, score: bestScore };
-    bestMarginDb = bestScore - Math.max(ta, tb);
+    // Weaker of the two per-link margins at the best cell (each link's own
+    // threshold), NOT bestScore - max(thresholds) — that pairing is wrong
+    // whenever the two thresholds differ.
+    const aBest = A.dbm[bestRow * A.width + bestCol];
+    const bBest = same
+      ? B.dbm?.[bestRow * A.width + bestCol] ?? NaN
+      : sampleNearest(B, lat, lon);
+    bestMarginDb = Math.min(aBest - ta, bBest - tb);
   }
 
   const overlap: CoverageResult = {

--- a/src/components/PointToPoint.vue
+++ b/src/components/PointToPoint.vue
@@ -98,8 +98,13 @@
         >
           Find bridge
         </button>
-        <button v-if="store.bridgeResult" type="button" class="mt-btn mt-btn-secondary mt-btn-sm" @click="store.clearBridge()">
-          Clear
+        <button
+          v-if="store.bridgeResult || store.bridgeState === 'computing'"
+          type="button"
+          class="mt-btn mt-btn-secondary mt-btn-sm"
+          @click="store.clearBridge()"
+        >
+          {{ store.bridgeState === 'computing' ? 'Cancel' : 'Clear' }}
         </button>
       </div>
 
@@ -136,7 +141,7 @@
             Bridge possible — {{ nCells }} candidate cell{{ nCells === 1 ? '' : 's' }} shown on the map
           </div>
           <dl class="mt-link-stats mt-2">
-            <div><dt>Bridgeable area</dt><dd>{{ fmt(store.bridgeResult.areaKm2) }} km²</dd></div>
+            <div><dt>Bridgeable area</dt><dd>{{ fmt(store.bridgeResult.areaKm2, 2) }} km²</dd></div>
             <div><dt>Best relay</dt><dd>{{ store.bridgeResult.best ? `${fmt(store.bridgeResult.best.lat, 5)}, ${fmt(store.bridgeResult.best.lon, 5)}` : '—' }}</dd></div>
             <div><dt>Signal at best</dt><dd>{{ store.bridgeResult.best ? fmt(store.bridgeResult.best.score, 1) : '—' }} dBm</dd></div>
             <div><dt>Margin</dt><dd :class="(store.bridgeResult.bestMarginDb ?? 0) >= 0 ? 'mt-pos' : 'mt-neg'">{{ store.bridgeResult.bestMarginDb == null ? '—' : `${(store.bridgeResult.bestMarginDb >= 0 ? '+' : '')}${fmt(store.bridgeResult.bestMarginDb, 1)} dB` }}</dd></div>

--- a/src/components/PointToPoint.vue
+++ b/src/components/PointToPoint.vue
@@ -73,6 +73,92 @@
         Recompute with current settings
       </button>
     </div>
+
+    <!-- Bridge-node placement: only relevant when the direct link can't get
+         through (below sensitivity). Reuses these same endpoints — the current
+         transmitter and the target above — to find where one added node could
+         relay between them. -->
+    <div
+      v-if="store.linkAnalysis && store.linkAnalysis.marginDb < 0"
+      class="mt-4 border-t border-line pt-3"
+    >
+      <p class="mt-hint mb-3">
+        The direct link can't reach here. Want to add a relay instead? The
+        planner runs the same radio model at the transmitter and this target,
+        then highlights everywhere a single added node could bridge them — where
+        it can hear <em>both</em> — and marks the best relay spot.
+      </p>
+
+      <div class="flex gap-2">
+        <button
+          type="button"
+          class="mt-btn mt-btn-primary mt-btn-sm flex-1"
+          :disabled="!canFind"
+          @click="store.findBridge()"
+        >
+          Find bridge
+        </button>
+        <button v-if="store.bridgeResult" type="button" class="mt-btn mt-btn-secondary mt-btn-sm" @click="store.clearBridge()">
+          Clear
+        </button>
+      </div>
+
+      <div
+        v-if="store.bridgeState === 'error'"
+        class="mt-3 rounded-lg border border-danger bg-danger-bg p-2 text-sm text-on-danger-bg"
+        role="alert"
+      >
+        {{ store.bridgeError }}
+      </div>
+
+      <div v-if="store.bridgeState === 'computing'" class="mt-3 flex items-center gap-2 text-sm text-ink-muted">
+        <span class="mt-spinner" role="status" aria-hidden="true"></span>
+        Computing coverage at each point…
+      </div>
+
+      <div v-if="store.bridgeResult && store.bridgeState === 'done'" class="mt-3">
+        <template v-if="store.bridgeResult.directLink">
+          <div class="mt-link-verdict mt-verdict-good">
+            <span class="mt-link-verdict-dot" aria-hidden="true"></span>
+            Direct link exists — no bridge needed
+          </div>
+          <dl class="mt-link-stats mt-2">
+            <div><dt>Direct-link margin</dt><dd :class="(store.bridgeResult.directMarginDb ?? 0) >= 0 ? 'mt-pos' : 'mt-neg'">{{ store.bridgeResult.directMarginDb == null ? '—' : `${(store.bridgeResult.directMarginDb >= 0 ? '+' : '')}${fmt(store.bridgeResult.directMarginDb, 1)} dB` }}</dd></div>
+          </dl>
+          <p class="mt-hint mt-2">
+            The site and this point already reach each other directly, so no
+            additional relay is required.
+          </p>
+        </template>
+        <template v-else-if="store.bridgeResult.hasOverlap">
+          <div class="mt-link-verdict mt-verdict-good">
+            <span class="mt-link-verdict-dot" aria-hidden="true"></span>
+            Bridge possible — {{ nCells }} candidate cell{{ nCells === 1 ? '' : 's' }} shown on the map
+          </div>
+          <dl class="mt-link-stats mt-2">
+            <div><dt>Bridgeable area</dt><dd>{{ fmt(store.bridgeResult.areaKm2) }} km²</dd></div>
+            <div><dt>Best relay</dt><dd>{{ store.bridgeResult.best ? `${fmt(store.bridgeResult.best.lat, 5)}, ${fmt(store.bridgeResult.best.lon, 5)}` : '—' }}</dd></div>
+            <div><dt>Signal at best</dt><dd>{{ store.bridgeResult.best ? fmt(store.bridgeResult.best.score, 1) : '—' }} dBm</dd></div>
+            <div><dt>Margin</dt><dd :class="(store.bridgeResult.bestMarginDb ?? 0) >= 0 ? 'mt-pos' : 'mt-neg'">{{ store.bridgeResult.bestMarginDb == null ? '—' : `${(store.bridgeResult.bestMarginDb >= 0 ? '+' : '')}${fmt(store.bridgeResult.bestMarginDb, 1)} dB` }}</dd></div>
+          </dl>
+          <p class="mt-hint mt-2">
+            The green shaded region is every cell that can hear both the site and
+            this target; the pin marks the spot with the strongest common signal.
+          </p>
+        </template>
+        <template v-else>
+          <div class="mt-link-verdict mt-verdict-bad">
+            <span class="mt-link-verdict-dot" aria-hidden="true"></span>
+            No single relay can bridge these two points
+          </div>
+          <p class="mt-hint mt-2">
+            With these parameters there is no place that reaches both. Try a
+            relay between them with higher power or a taller antenna, or plan a
+            2-relay chain.
+          </p>
+        </template>
+      </div>
+    </div>
   </div>
 </template>
 
@@ -102,7 +188,19 @@ function applyCoords() {
   store.setLinkTarget(lat, lon);
 }
 
-const fmt = (n: number, d: number) => (Number.isFinite(n) ? n.toFixed(d) : '–');
+const fmt = (n: number, d = 0) => (Number.isFinite(n) ? n.toFixed(d) : '–');
+
+// Bridge-node placement: enabled once a target exists and no computation is in
+// flight. Only shown to the user when the direct link is below sensitivity.
+const canFind = computed(() => !!store.linkTarget && store.bridgeState !== 'computing');
+
+const nCells = computed(() => {
+  const r = store.bridgeResult;
+  if (!r) return 0;
+  let n = 0;
+  for (let i = 0; i < r.overlap.dbm.length; i++) if (!Number.isNaN(r.overlap.dbm[i])) n++;
+  return n;
+});
 
 const rayColor = computed(() => {
   const a = store.linkAnalysis;

--- a/src/layers.ts
+++ b/src/layers.ts
@@ -58,3 +58,27 @@ export function targetPinElement(): HTMLElement {
   el.innerHTML = TARGET_PIN_SVG;
   return el;
 }
+
+/* Recommended bridge-relay pin: a YELLOW teardrop carrying a Venn "inner-join"
+ * glyph. Section A (left-only) is yellow, the overlap lens AB is black, section
+ * B (right-only) is yellow — so the shared join region reads as the shaded
+ * intersection. Distinct from the green/site and blue/target pins. Anchored at
+ * 'bottom' like the other markers. */
+const BRIDGE_PIN_SVG = `
+<svg xmlns="http://www.w3.org/2000/svg" width="34" height="44" viewBox="0 0 34 44">
+  <path d="M17 1C8.16 1 1 8.16 1 17c0 11.5 13.2 24.06 15.06 25.78a1.4 1.4 0 0 0 1.88 0C19.8 41.06 33 28.5 33 17 33 8.16 25.84 1 17 1Z"
+        fill="#f5c518" stroke="#0f1017" stroke-width="1.5"/>
+  <svg x="5" y="10" width="24" height="20" viewBox="0 0 24 20" preserveAspectRatio="xMidYMid meet">
+    <path d="M12 3.68 A7 7 0 0 1 12 16.32 A7 7 0 0 1 12 3.68 Z" fill="#000000"/>
+    <circle cx="9"  cy="10" r="7" fill="none" stroke="#0f1017" stroke-width="1.8"/>
+    <circle cx="15" cy="10" r="7" fill="none" stroke="#0f1017" stroke-width="1.8"/>
+  </svg>
+</svg>`;
+
+/** Marker for the recommended bridge-relay placement (yellow join pin). */
+export function bridgePinElement(): HTMLElement {
+  const el = document.createElement('div');
+  el.className = 'mt-pin mt-pin-bridge';
+  el.innerHTML = BRIDGE_PIN_SVG;
+  return el;
+}

--- a/src/map/overlay.ts
+++ b/src/map/overlay.ts
@@ -142,3 +142,66 @@ export function coverageImage(
     ],
   };
 }
+
+/**
+ * Render the bridgeable (coverage-overlap) region as a DISTINCT green
+ * "recommended relay zone" highlight — deliberately a different hue from the
+ * normal coverage heatmaps (plasma/…), so it reads as the spot to add a node
+ * rather than another coverage disk. Stronger overlap (min of the two signals)
+ * -> brighter + more opaque.
+ */
+export function bridgeSelectionImage(
+  result: CoverageResult,
+  display: DisplaySettings,
+  sensitivityDbm: number
+): CoverageImage {
+  const { width, height, dbm, bounds } = result;
+  const min = display.min_dbm;
+  const max = display.max_dbm;
+  const span = max > min ? max - min : 1;
+
+  const srcRGBA = new Uint8ClampedArray(width * height * 4);
+  for (let i = 0; i < width * height; i++) {
+    const v = dbm[i];
+    if (Number.isNaN(v) || v < sensitivityDbm) continue; // transparent
+    let t = (v - min) / span;
+    if (t < 0) t = 0;
+    if (t > 1) t = 1;
+    const o = i * 4;
+    // Teal-green ramp (distinct from the coverage colormaps): dimmer/translucent
+    // at the edges, bright solid green at the strongest overlap.
+    srcRGBA[o] = 34 + Math.round(t * 96); //  34 -> 130
+    srcRGBA[o + 1] = 156 + Math.round(t * 82); // 156 -> 238
+    srcRGBA[o + 2] = 110 + Math.round(t * 60); // 110 -> 170
+    srcRGBA[o + 3] = Math.round(150 + t * 100); // alpha 150 -> 250
+  }
+
+  const yN = mercatorY(bounds.north);
+  const yS = mercatorY(bounds.south);
+  const dpp = result.pixelDegrees;
+  const out = new Uint8ClampedArray(srcRGBA.length);
+  const rowBytes = width * 4;
+  for (let r = 0; r < height; r++) {
+    const y = yN + ((r + 0.5) / height) * (yS - yN);
+    const lat = latFromMercatorY(y);
+    let srcRow = Math.floor((bounds.north - lat) / dpp);
+    if (srcRow < 0) srcRow = 0;
+    if (srcRow >= height) srcRow = height - 1;
+    out.set(srcRGBA.subarray(srcRow * rowBytes, (srcRow + 1) * rowBytes), r * rowBytes);
+  }
+
+  const canvas = document.createElement('canvas');
+  canvas.width = width;
+  canvas.height = height;
+  canvas.getContext('2d')!.putImageData(new ImageData(out, width, height), 0, 0);
+
+  return {
+    url: canvas.toDataURL('image/png'),
+    coordinates: [
+      [bounds.west, bounds.north],
+      [bounds.east, bounds.north],
+      [bounds.east, bounds.south],
+      [bounds.west, bounds.south],
+    ],
+  };
+}

--- a/src/store.ts
+++ b/src/store.ts
@@ -4,11 +4,11 @@ import { randanimalSync } from 'randanimal';
 import maplibregl from 'maplibre-gl';
 import { type Site, type SplatParams } from './types.ts';
 import { cloneObject } from './utils.ts';
-import { draftPinElement, sitePinElement, targetPinElement } from './layers.ts';
+import { draftPinElement, sitePinElement, targetPinElement, bridgePinElement } from './layers.ts';
 import { BASEMAPS, DEFAULT_BASEMAP, applyBasemap, emptyStyle } from './map/styles.ts';
 import { BasemapControl, ExportControl, MeasureControl } from './map/controls.ts';
 import { SearchControl } from './map/search.ts';
-import { coverageImage, cropToRadius } from './map/overlay.ts';
+import { coverageImage, cropToRadius, bridgeSelectionImage } from './map/overlay.ts';
 import { coverageContours } from './map/contours.ts';
 import { canShareFiles, exportGeoJSON, exportKml, exportPngWorldFile, postCoverageToBridge, shareGeoJSON } from './map/export.ts';
 import type { WasmCoverageEngine } from './engine/WasmCoverageEngine.ts';
@@ -25,6 +25,7 @@ import {
   clearSharedQuery,
 } from './permalink.ts';
 import { coverageStats } from './coverageStats.ts';
+import { computeBridge, type BridgeResult } from './bridge.ts';
 import { TerrainService } from './terrain/TerrainService.ts';
 
 // Module-level singletons: workers, terrain cache, and map handles outlive
@@ -43,6 +44,7 @@ let targetMarker: maplibregl.Marker | undefined;
 let linkEscHandler: ((e: KeyboardEvent) => void) | undefined;
 let linkClickHandler: ((e: maplibregl.MapMouseEvent) => void) | undefined;
 let linkAbort: AbortController | undefined;
+let bridgeAbort: AbortController | undefined;
 const LINK_LINE_ID = 'mt-p2p-link';
 // Measure/ruler tool (#15).
 let measureControl: MeasureControl | undefined;
@@ -50,6 +52,10 @@ let measureClickHandler: ((e: maplibregl.MapMouseEvent) => void) | undefined;
 let measureEscHandler: ((e: KeyboardEvent) => void) | undefined;
 let measureA: { lat: number; lon: number } | null = null;
 const MEASURE_SRC = 'mt-measure';
+// Bridge-node placement (#bridge): best-placement marker + overlay source/layer ids.
+let bridgeMarker: maplibregl.Marker | undefined;
+const BRIDGE_SRC = 'mt-bridge';
+const BRIDGE_LAYER = 'mt-bridge';
 
 /** Wrap a longitude into [-180, 180). */
 function wrapLon(lon: number): number {
@@ -237,6 +243,12 @@ const useStore = defineStore('store', {
       /** Measure/ruler tool (#15). */
       measureMode: false,
       measureResult: null as { distanceKm: number; bearingDeg: number } | null,
+      /** Bridge-node placement: reuses the point-to-point link endpoints — the
+       * current transmitter (site A) and the map link target (point B), whose
+       * coverage grids are computed on demand. Stores the overlap + best spot. */
+      bridgeResult: null as BridgeResult | null,
+      bridgeState: 'idle' as 'idle' | 'computing' | 'done' | 'error',
+      bridgeError: '',
     }
   },
   actions: {
@@ -639,6 +651,120 @@ const useStore = defineStore('store', {
       }
     },
 
+    /* ---- Bridge-node placement ---- */
+    /** Remove the bridge overlay, its source, and the best-placement marker. */
+    removeBridgeOverlay() {
+      if (!map) return;
+      for (const id of [BRIDGE_LAYER, `${BRIDGE_LAYER}-line`]) {
+        if (map.getLayer(id)) map.removeLayer(id);
+      }
+      if (map.getSource(BRIDGE_SRC)) map.removeSource(BRIDGE_SRC);
+      bridgeMarker?.remove();
+      bridgeMarker = undefined;
+    },
+    /** All workable bridge cells are shown; the `best` cell is highlighted. */
+    syncBridgeOverlay() {
+      if (!map) return;
+      this.removeBridgeOverlay();
+      const res = this.bridgeResult;
+      // If the sites already talk directly (or have no overlap), there is
+      // no relay zone to draw — the panel conveys the message instead.
+      if (!res || res.directLink || !res.hasOverlap) return;
+      const display = this.splatParams.display;
+      // Distinct green "recommended relay zone" layer, on top of the site
+      // coverage overlays. sensitivity -Infinity keeps every stored overlap
+      // cell visible (NaN is already transparent).
+      const image = bridgeSelectionImage(res.overlap, display, -Infinity);
+      map.addSource(BRIDGE_SRC, {
+        type: 'image',
+        url: image.url,
+        coordinates: image.coordinates,
+      });
+      map.addLayer({
+        id: BRIDGE_LAYER,
+        type: 'raster',
+        source: BRIDGE_SRC,
+        paint: { 'raster-opacity': 1, 'raster-resampling': 'nearest' },
+      });
+      if (res.best && !bridgeMarker) {
+        bridgeMarker = new maplibregl.Marker({ element: bridgePinElement(), anchor: 'bottom' })
+          .setLngLat([res.best.lon, res.best.lat])
+          .addTo(map);
+      }
+    },
+    /**
+     * Bridge the point-to-point link's two endpoints: the current transmitter
+     * (site A, from the link tool's settings) and the map link target (point
+     * B). Both are given the SAME site + receiver values (the device you're
+     * planning for), so each endpoint's coverage grid is computed on demand
+     * with the identical engine, then the usual coverage-overlap analysis
+     * finds where one relay can hear both.
+     */
+    async findBridge() {
+      const b = this.linkTarget;
+      if (!b) {
+        this.bridgeState = 'error';
+        this.bridgeError = 'Pick a second point on the map first (use "Pick target on map").';
+        return;
+      }
+      this.bridgeState = 'computing';
+      this.bridgeError = '';
+      bridgeAbort?.abort();
+      bridgeAbort = new AbortController();
+      const signal = bridgeAbort.signal;
+      try {
+        // Site A is the current transmitter; point B carries the same radio,
+        // moved to the chosen location.
+        const aParams = cloneObject(this.splatParams);
+        const bParams = cloneObject(aParams);
+        bParams.transmitter.tx_lat = b.lat;
+        bParams.transmitter.tx_lon = b.lon;
+        // Widen each endpoint's radius so its coverage reaches the other and
+        // spans the overlap region (capped at the model's data limit).
+        const distKm = haversineKm(aParams.transmitter.tx_lat, aParams.transmitter.tx_lon, b.lat, b.lon);
+        const radius = Math.min(MAX_RADIUS_METERS, Math.max(aParams.simulation.simulation_extent * 1000, (distKm * 1.2 + 2) * 1000));
+
+        const runAt = async (params: SplatParams) => {
+          const request = buildCoverageRequest(params);
+          request.radius = radius;
+          const result = await (await getEngine()).run(toEngineParams(request), { terrain: getTerrain(), signal });
+          if (signal.aborted) return null;
+          return cropToRadius(result, request.lat, request.lon, request.radius);
+        };
+
+        // Run sequentially — the engine is a single-instance worker pool and
+        // only accepts one run() at a time (its `busy` guard throws otherwise).
+        const gridA = await runAt(aParams);
+        if (signal.aborted || !gridA) return;
+        const gridB = await runAt(bParams);
+        if (signal.aborted || !gridB) return;
+
+        this.bridgeResult = computeBridge({
+          resultA: gridA,
+          resultB: gridB,
+          thresholdA: aParams.receiver.rx_sensitivity,
+          thresholdB: bParams.receiver.rx_sensitivity,
+          txLatA: aParams.transmitter.tx_lat,
+          txLonA: aParams.transmitter.tx_lon,
+          txLatB: b.lat,
+          txLonB: b.lon,
+        });
+        this.bridgeState = 'done';
+        this.syncBridgeOverlay();
+      } catch (error) {
+        if (error instanceof DOMException && error.name === 'AbortError') return;
+        this.bridgeError = error instanceof Error ? error.message : String(error);
+        this.bridgeState = 'error';
+      }
+    },
+    clearBridge() {
+      bridgeAbort?.abort();
+      this.bridgeResult = null;
+      this.bridgeState = 'idle';
+      this.bridgeError = '';
+      this.removeBridgeOverlay();
+    },
+
     removeSite(index: number) {
       const [removed] = this.localSites.splice(index, 1)
       if (removed) {
@@ -738,6 +864,9 @@ const useStore = defineStore('store', {
           });
         }
       });
+      // Re-apply the bridge relay-zone layer LAST so it always sits on top of
+      // the per-site coverage overlays (even after toggling site visibility).
+      this.syncBridgeOverlay();
     },
     initMap() {
       map = new maplibregl.Map({

--- a/src/store.ts
+++ b/src/store.ts
@@ -357,6 +357,8 @@ const useStore = defineStore('store', {
     /** Set or move the link target, then (re)compute the link. */
     setLinkTarget(lat: number, lon: number) {
       this.linkTarget = { lat, lon };
+      // The bridge analysis depends on this target — clear any stale result.
+      this.clearBridge();
       this.drawLink();
       void this.computeLink();
     },
@@ -407,6 +409,8 @@ const useStore = defineStore('store', {
       this.linkAnalysis = null;
       this.linkState = 'idle';
       this.linkError = '';
+      // The bridge analysis depends on the target being present — clear it.
+      this.clearBridge();
       targetMarker?.remove();
       targetMarker = undefined;
       if (map?.getLayer(LINK_LINE_ID)) map.removeLayer(LINK_LINE_ID);
@@ -707,9 +711,11 @@ const useStore = defineStore('store', {
         this.bridgeError = 'Pick a second point on the map first (use "Pick target on map").';
         return;
       }
+      // Invalidate any previous bridge output before starting a new run, so a
+      // stale overlay/result never lingers while (or if) this one computes.
+      this.clearBridge();
       this.bridgeState = 'computing';
       this.bridgeError = '';
-      bridgeAbort?.abort();
       bridgeAbort = new AbortController();
       const signal = bridgeAbort.signal;
       try {

--- a/test/bridge.test.ts
+++ b/test/bridge.test.ts
@@ -91,20 +91,102 @@ describe('computeBridge', () => {
     expect(Array.from(r.overlap.dbm)).toEqual([-80, -80, -80, -80]);
   });
 
-  it('reports a direct link (no bridge needed) when each site hears the other', () => {
-    // Both transmitters sit in the centre where both grids are strong (-80 ≥ -130).
-    const a = grid([-80, -80, -80, -80], 2, 2);
-    const b = grid([-80, -80, -80, -80], 2, 2);
+  it('resamples non-uniform B columns to the NEAREST pixel center', () => {
+    // A coarse 2x2 (0.01°/cell over ±0.01°); B fine 5x5 (0.004°/cell) over the
+    // SAME span, with a DISTINCT dBm per B column so the sampled column is
+    // observable: col0=-80, col1=-90, col2=-100, col3=-110, col4=-120.
+    const a = grid([-80, -80, -80, -80], 2, 2, 0.01);
+    const b = grid(
+      [-80, -90, -100, -110, -120,
+       -80, -90, -100, -110, -120,
+       -80, -90, -100, -110, -120,
+       -80, -90, -100, -110, -120,
+       -80, -90, -100, -110, -120],
+      5, 5, 0.004
+    );
+    // Both rasters span ±0.01°. A cell centers sit at lon = -0.005 (col0) and
+    // +0.005 (col1). B column centers are at -0.008, -0.004, 0, +0.004, +0.008,
+    // so each A center maps unambiguously (no tie):
+    //  - A col0 (-0.005) → nearest B col1 (-90), margin 0.001 vs col0 (-80)
+    //  - A col1 (+0.005) → nearest B col3 (-110), margin 0.001 vs col4 (-120)
     const r = computeBridge({ resultA: a, resultB: b, thresholdA: THRESHOLD, thresholdB: THRESHOLD, ...TX });
-    expect(r.directLink).toBe(true);
-    expect(r.directMarginDb).toBeCloseTo(-80 - THRESHOLD, 6); // 50 dB of margin
+    expect(r.hasOverlap).toBe(true);
+    // Overlap = min(A,B): A(-80) with B col1 → -90; A(-80) with B col3 → -110.
+    expect(Array.from(r.overlap.dbm)).toEqual([-90, -110, -90, -110]);
+    expect(r.best!.score).toBeCloseTo(-90, 6); // stronger overlap on the left pair
   });
 
-  it('does NOT report a direct link when the sites cannot hear each other', () => {
-    // Both transmitters in the centre, but each site is weak (-140 < -130) there.
-    const weak = grid([-140, -140, -140, -140], 2, 2);
-    const r = computeBridge({ resultA: weak, resultB: weak, thresholdA: THRESHOLD, thresholdB: THRESHOLD, txLatA: 0, txLonA: 0, txLatB: 0, txLonB: 0 });
-    expect(r.directLink).toBe(false);
-    expect(r.directMarginDb).toBeCloseTo(-140 - THRESHOLD, 6); // negative margin
+  it('skips B columns outside the raster longitude range (no phantom wrap)', () => {
+    // A spans lon [-0.01, +0.01]; B is FAR east, spanning [10, 10.008] with a
+    // strong center column. A's cells are genuinely outside B's longitude
+    // extent, so they must NOT be wrapped onto a bogus B column.
+    const a = grid([-70, -70, -70, -70], 2, 2, 0.01); // lat/lon ≈ 0
+    const b: CoverageResult = {
+      dbm: Float32Array.from([-80, -80, -80, -80]),
+      width: 2,
+      height: 2,
+      bounds: { north: 0.01, south: -0.01, west: 10, east: 10.01 },
+      pixelDegrees: 0.005,
+      stats: { radials: 0, pages: 0, pagesWithData: 0, itmWarnings: [], elapsedMs: 0, workers: 1 },
+    };
+    const r = computeBridge({ resultA: a, resultB: b, thresholdA: THRESHOLD, thresholdB: THRESHOLD, txLatA: 0, txLonA: 0, txLatB: 0, txLonB: 0 });
+    // Every A cell lies ~10° from B, outside its longitude span → none overlap.
+    expect(r.hasOverlap).toBe(false);
+    expect(Array.from(r.overlap.dbm).every(Number.isNaN)).toBe(true);
+    expect(r.best).toBeNull();
+  });
+
+  it('reports a direct link (no bridge needed) when each site hears the other', () => {
+    // Distinct TX coordinates + non-uniform rasters so each direction is checked
+    // independently. A and B are each 2x2 (row-major, bounds ±0.01°); cell (TR,
+    // index 1) sits at lat 0.005, lon 0.005 and cell (TL, index 0) at 0.005, -0.005.
+    const a = grid([-140, -90, -140, -140], 2, 2); // A strong only at TR (idx 1)
+    const b = grid([-140, -95, -140, -140], 2, 2); // B strong only at TR (idx 1)
+    // TX-B sits on A's TR cell  → aAtB = A's signal at B = -90.
+    // TX-A sits on B's TR cell  → bAtA = B's signal at A = -95.
+    const r = computeBridge({
+      resultA: a, resultB: b,
+      thresholdA: THRESHOLD, thresholdB: THRESHOLD,
+      txLatA: 0.005, txLonA: 0.005, txLatB: 0.005, txLonB: 0.005,
+    });
+    expect(r.directLink).toBe(true); // -90 ≥ -130 AND -95 ≥ -130
+    expect(r.directMarginDb).toBeCloseTo(Math.min(-90 - THRESHOLD, -95 - THRESHOLD), 6); // min(40, 35) = 35
+  });
+
+  it('does NOT report a direct link when a site is below threshold at the other', () => {
+    // TX-B sits on a WEAK A cell (idx 1 = -140 < -130); TX-A on a strong B cell.
+    const a = grid([-140, -140, -140, -140], 2, 2);
+    const b = grid([-140, -95, -140, -140], 2, 2);
+    const r = computeBridge({
+      resultA: a, resultB: b,
+      thresholdA: THRESHOLD, thresholdB: THRESHOLD,
+      txLatA: 0.005, txLonA: 0.005, txLatB: 0.005, txLonB: 0.005,
+    });
+    expect(r.directLink).toBe(false); // aAtB = -140 < -130
+    expect(r.directMarginDb).toBeCloseTo(Math.min(-140 - THRESHOLD, -95 - THRESHOLD), 6); // min(-10, 35) = -10
+  });
+
+  it('direct-link margin uses each endpoint threshold when they differ', () => {
+    const a = grid([-140, -90, -140, -140], 2, 2); // A hears B at -90
+    const b = grid([-140, -95, -140, -140], 2, 2); // B hears A at -95
+    const r = computeBridge({
+      resultA: a, resultB: b,
+      thresholdA: -120, thresholdB: -100, // distinct per endpoint
+      txLatA: 0.005, txLonA: 0.005, txLatB: 0.005, txLonB: 0.005,
+    });
+    // aAtB = -90 (vs -120) → margin 30; bAtA = -95 (vs -100) → margin 5.
+    expect(r.directLink).toBe(true); // -90 ≥ -120 AND -95 ≥ -100
+    expect(r.directMarginDb).toBeCloseTo(Math.min(-90 - -120, -95 - -100), 6); // min(30, 5) = 5
+  });
+
+  it('best margin is the SMALLER per-link margin when thresholds differ', () => {
+    // Best cell: A=-100 (margin vs ta=-120 → 20), B=-95 (margin vs tb=-100 → 5).
+    // min(A,B) = -100, but the weaker per-link margin is 5, NOT 0 (= bestScore - max(t)).
+    const a = grid([-100, -100, -100, -100], 2, 2);
+    const b = grid([-95, -95, -95, -95], 2, 2);
+    const r = computeBridge({ resultA: a, resultB: b, thresholdA: -120, thresholdB: -100, ...TX });
+    expect(r.hasOverlap).toBe(true);
+    expect(r.bestMarginDb).toBeCloseTo(5, 6); // min(20, 5) = 5
+    expect(r.best!.score).toBeCloseTo(-100, 6); // min(A,B) unchanged
   });
 });

--- a/test/bridge.test.ts
+++ b/test/bridge.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect } from 'vitest';
+
+import { computeBridge } from '../src/bridge';
+import type { CoverageResult } from '../src/engine/CoverageEngine';
+
+/** Minimal CoverageResult around the equator (cos(lat) ~ 1), matching the
+ * helper in coverageStats.test.ts. Cells are ~1.24 km² at pixelDegrees 0.01. */
+function grid(dbm: number[], width: number, height: number, pixelDegrees = 0.01): CoverageResult {
+  const halfH = (height * pixelDegrees) / 2;
+  const halfW = (width * pixelDegrees) / 2;
+  return {
+    dbm: Float32Array.from(dbm),
+    width,
+    height,
+    bounds: { north: halfH, south: -halfH, west: -halfW, east: halfW },
+    pixelDegrees,
+    stats: { radials: 0, pages: 0, pagesWithData: 0, itmWarnings: [], elapsedMs: 0, workers: 1 },
+  };
+}
+
+const THRESHOLD = -130;
+// Transmitters sit at the grid centre for both sites (both grids are origin-centered).
+const TX = { txLatA: 0, txLonA: 0, txLatB: 0, txLonB: 0 };
+
+describe('computeBridge', () => {
+  it('full overlap of two identical strong sites', () => {
+    const a = grid([-100, -100, -100, -100], 2, 2);
+    const r = computeBridge({ resultA: a, resultB: grid([-100, -100, -100, -100], 2, 2), thresholdA: THRESHOLD, thresholdB: THRESHOLD, ...TX });
+    expect(r.hasOverlap).toBe(true);
+    expect(r.best).not.toBeNull();
+    expect(r.best!.score).toBeCloseTo(-100, 6);
+    // All 4 cells overlap → ~4.96 km².
+    expect(r.areaKm2).toBeCloseTo(4.96, 0);
+    expect(Array.from(r.overlap.dbm)).toEqual([-100, -100, -100, -100]);
+  });
+
+  it('no overlap when the sites do not reach each other (B has no coverage)', () => {
+    const a = grid([-90, -90, -90, -90], 2, 2);
+    const b = grid([NaN, NaN, NaN, NaN], 2, 2);
+    const r = computeBridge({ resultA: a, resultB: b, thresholdA: THRESHOLD, thresholdB: THRESHOLD, ...TX });
+    expect(r.hasOverlap).toBe(false);
+    expect(r.best).toBeNull();
+    expect(r.bestMarginDb).toBeNull();
+    expect(r.areaKm2).toBe(0);
+    expect(Array.from(r.overlap.dbm).every(Number.isNaN)).toBe(true);
+  });
+
+  it('overlap is the coverage intersection, scored by min(A,B)', () => {
+    // A strong on the LEFT pair, weak (below threshold) on the RIGHT pair.
+    const a = grid([-80, -80, -140, -140], 2, 2);
+    // B strong on the TOP pair, weak on the BOTTOM pair.
+    const b = grid([-80, -140, -80, -140], 2, 2);
+    const r = computeBridge({ resultA: a, resultB: b, thresholdA: THRESHOLD, thresholdB: THRESHOLD, ...TX });
+    // Only cell (top-left) hears both; that's the bridgeable region.
+    expect(r.hasOverlap).toBe(true);
+    expect(r.areaKm2).toBeCloseTo(1.24, 0);
+    expect(r.best!.lat).toBeCloseTo(0.005, 6);
+    expect(r.best!.lon).toBeCloseTo(-0.005, 6);
+    expect(r.best!.score).toBeCloseTo(-80, 6);
+    expect(r.bestMarginDb).toBeCloseTo(-80 - THRESHOLD, 6); // 50 dB of margin
+    // Overlap grid: only top-left populated.
+    expect(r.overlap.dbm[0]).toBeCloseTo(-80, 6);
+    expect(Number.isNaN(r.overlap.dbm[1])).toBe(true);
+    expect(Number.isNaN(r.overlap.dbm[2])).toBe(true);
+    expect(Number.isNaN(r.overlap.dbm[3])).toBe(true);
+  });
+
+  it('best placement maximizes min(A,B)', () => {
+    // A strong everywhere. B strongest at top-left, weaker elsewhere.
+    const a = grid([-110, -110, -110, -110], 2, 2);
+    const b = grid([-60, -120, -120, -120], 2, 2);
+    const r = computeBridge({ resultA: a, resultB: b, thresholdA: THRESHOLD, thresholdB: THRESHOLD, ...TX });
+    // All 4 cells overlap; min() is -110 at top-left (A is the weak link there),
+    // and -120 elsewhere → best is the top-left cell.
+    expect(r.hasOverlap).toBe(true);
+    expect(r.best!.score).toBeCloseTo(-110, 6);
+    expect(r.best!.lat).toBeCloseTo(0.005, 6);
+    expect(r.best!.lon).toBeCloseTo(-0.005, 6);
+  });
+
+  it('resamples a non-aligned (finer) second grid onto the first', () => {
+    // A coarse 2x2 (0.01°/cell); B fine 4x4 (0.005°/cell) over the SAME bounds.
+    const a = grid([-80, -80, -80, -80], 2, 2, 0.01);
+    const b = grid(
+      [-80, -80, -80, -80, -80, -80, -80, -80, -80, -80, -80, -80, -80, -80, -80, -80],
+      4, 4, 0.005
+    );
+    const r = computeBridge({ resultA: a, resultB: b, thresholdA: THRESHOLD, thresholdB: THRESHOLD, ...TX });
+    expect(r.hasOverlap).toBe(true);
+    expect(r.areaKm2).toBeCloseTo(4.96, 0); // all 4 coarse cells overlap
+    expect(Array.from(r.overlap.dbm)).toEqual([-80, -80, -80, -80]);
+  });
+
+  it('reports a direct link (no bridge needed) when each site hears the other', () => {
+    // Both transmitters sit in the centre where both grids are strong (-80 ≥ -130).
+    const a = grid([-80, -80, -80, -80], 2, 2);
+    const b = grid([-80, -80, -80, -80], 2, 2);
+    const r = computeBridge({ resultA: a, resultB: b, thresholdA: THRESHOLD, thresholdB: THRESHOLD, ...TX });
+    expect(r.directLink).toBe(true);
+    expect(r.directMarginDb).toBeCloseTo(-80 - THRESHOLD, 6); // 50 dB of margin
+  });
+
+  it('does NOT report a direct link when the sites cannot hear each other', () => {
+    // Both transmitters in the centre, but each site is weak (-140 < -130) there.
+    const weak = grid([-140, -140, -140, -140], 2, 2);
+    const r = computeBridge({ resultA: weak, resultB: weak, thresholdA: THRESHOLD, thresholdB: THRESHOLD, txLatA: 0, txLonA: 0, txLatB: 0, txLonB: 0 });
+    expect(r.directLink).toBe(false);
+    expect(r.directMarginDb).toBeCloseTo(-140 - THRESHOLD, 6); // negative margin
+  });
+});


### PR DESCRIPTION
## Summary

When a **Point-to-point link** comes back **below sensitivity** (the transmitter and target can't talk directly), the planner now helps find where to put **one** extra node to relay between them.

The link card gains a **"Find bridge"** section (shown only when the link is too weak) that:
- runs coverage at **both** endpoints using the site's own radio + receiver values,
- highlights every cell where a single added node can hear **both** (the **coverage overlap**),
- marks the **single best** relay spot (the cell maximizing the weaker signal),
- reports the bridgeable area, best coordinates, signal strength and margin.

## Motivation

Field planning often ends with "the direct path is blocked — can I throw one relay node at it?" This answers that question with the exact same radio/terrain model the app already runs, reusing the point-to-point link's transmitter + target. No second simulation required.

## How it works

- The **point-to-point link** section is unchanged: pick the transmitter and a target.
- When the link verdict is below sensitivity, a relay section appears.
- **Find bridge** computes a coverage grid at the transmitter (A) and at the target (B) with the identical engine, then computes the overlap: every cell where `A >= rx_sensitivity` AND `B >= rx_sensitivity`.
- Because links are modeled symmetrically, a node in the overlap can hear both — that's the bridgeable region.
- Best placement = the overlap cell maximizing `min(A, B)`.

## Changes

- `src/bridge.ts` — new pure module: `computeBridge()` returns the overlap grid (shaped like a `CoverageResult` so it drops straight into the existing render pipeline), the best placement, area, margin, and a **direct-link** flag. DOM-free and unit-testable, mirroring `coverageStats.ts` / `coverageContours.ts`.
- `src/components/PointToPoint.vue` — relay section shown only when the direct link is below sensitivity; **Find bridge / Clear** + result states (direct link / bridge possible / no single relay).
- `src/store.ts` — `findBridge` / `clearBridge` + overlay & marker sync; the two coverage runs are **serial** (the engine is a single-instance worker pool); the relay-zone layer stays on top after visibility toggles.
- `src/map/overlay.ts` — `bridgeSelectionImage()` renders the relay zone as a **distinct green** layer (a different hue from the normal coverage heatmaps).
- `src/layers.ts` — `bridgePinElement()`: a yellow teardrop with a Venn **inner-join** glyph (A=yellow, overlap=black, B=yellow) for the recommended relay spot.
- `test/bridge.test.ts` — unit tests for `computeBridge` (full/empty overlap, min-scoring of best placement, non-aligned grid resampling, direct-link detection).

## Testing

- `pnpm test` — passes (new `bridge.test.ts` plus existing suites).
- `pnpm build` (`vue-tsc -b && vite build`) — passes.
- Manually verified: a weak link shows the relay section and draws the green overlap + best pin; a viable link does not show the section.

## Notes / assumptions

- The relay section only appears when the link is below sensitivity — the case where a bridge is actually useful.
- "A node in the overlap bridges the two" assumes the relay's receiver is modeled at each endpoint's threshold (consistent with how coverage and links are treated elsewhere).
- Overlap precision is bounded by the coarser of the two grids (mixed resolutions are resampled to the first).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added bridge planning when direct signal is insufficient.
  * Identifies the strongest relay location, bridgeable area, and signal margin.
  * Added map overlays highlighting viable relay zones and suggested relay locations.
  * Added controls to calculate, cancel, and clear bridge analysis.
  * Reports direct-link availability or when no suitable relay can be found.

* **Bug Fixes**
  * Improved handling of missing coverage, invalid grids, and unavailable overlap areas.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->